### PR TITLE
Disable Werror during torchvision vision header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,9 @@ else()
   )
 endif() # TRITON_PYTORCH_DOCKER_BUILD
 
-# Need to turn off -Werror due to Torchvision vision header extern initialization
+# Need to turn off -Werror due to Torchvision vision.h extern initialization
+# Unfortunately gcc does not provide a specific flag to ignore the specific
+# warning: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=45977
 target_compile_features(triton-pytorch-backend PRIVATE cxx_std_11)
 target_compile_options(
   triton-pytorch-backend PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,11 +218,12 @@ else()
   )
 endif() # TRITON_PYTORCH_DOCKER_BUILD
 
+# Need to turn off -Werror due to Torchvision vision header extern initialization
 target_compile_features(triton-pytorch-backend PRIVATE cxx_std_11)
 target_compile_options(
   triton-pytorch-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-    -Wall -Wextra -Wno-unused-parameter -Wno-type-limits -Werror>
+    -Wall -Wextra -Wno-unused-parameter -Wno-type-limits>
 )
 
 if(${TRITON_ENABLE_GPU})

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -37,7 +37,7 @@
 
 // Suppress warnings in torch headers
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wsign-compare -Werror"
 #pragma warning(push, 0)
 #include <torchvision/ops/ops.h>
 #include <torchvision/vision.h>  // Torchvision header

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -37,7 +37,8 @@
 
 // Suppress warnings in torch headers
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-compare -Werror"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma warning(push, 0)
 #include <torchvision/ops/ops.h>
 #include <torchvision/vision.h>  // Torchvision header

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -38,7 +38,6 @@
 // Suppress warnings in torch headers
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma warning(push, 0)
 #include <torchvision/ops/ops.h>
 #include <torchvision/vision.h>  // Torchvision header


### PR DESCRIPTION
- extern initialzied while being declared in vision.h
PS: Needed by 21.03 container since it picks up the new Torchvision changes that cause this issue. 