### PR TITLE
Remove default TRITON_PYTORCH_DOCKER_IMAGE value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,7 @@ project(tritonpytorchbackend LANGUAGES C CXX)
 #
 option(TRITON_ENABLE_GPU "Enable GPU support in backend" ON)
 option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
-set(TRITON_PYTORCH_DOCKER_IMAGE "nvcr.io/nvidia/pytorch:20.12-py3" CACHE STRING
-    "Docker image containing the PyTorch build required by backend.")
+set(TRITON_PYTORCH_DOCKER_IMAGE "Docker image containing the PyTorch build required by backend.")
 set(TRITON_PYTORCH_INCLUDE_PATHS "" CACHE PATH "Paths to Torch includes")
 set(TRITON_PYTORCH_LIB_PATHS "" CACHE PATH "Paths to Torch libraries")
 
@@ -58,6 +57,9 @@ endif()
 
 set(TRITON_PYTORCH_DOCKER_BUILD OFF)
 if(TRITON_PYTORCH_LIB_PATHS STREQUAL "")
+  if (TRITON_PYTORCH_DOCKER_IMAGE)
+    message(FATAL_ERROR "Using the PyTorch docker based build requires TRITON_PYTORCH_DOCKER_IMAGE")
+  endif()
   set(TRITON_PYTORCH_DOCKER_BUILD ON)
 endif()
 message(STATUS "Using PyTorch docker: ${TRITON_PYTORCH_DOCKER_IMAGE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ project(tritonpytorchbackend LANGUAGES C CXX)
 #
 option(TRITON_ENABLE_GPU "Enable GPU support in backend" ON)
 option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
-set(TRITON_PYTORCH_DOCKER_IMAGE "Docker image containing the PyTorch build required by backend.")
+set(TRITON_PYTORCH_DOCKER_IMAGE "" CACHE STRING "Docker image containing the PyTorch build required by backend.")
 set(TRITON_PYTORCH_INCLUDE_PATHS "" CACHE PATH "Paths to Torch includes")
 set(TRITON_PYTORCH_LIB_PATHS "" CACHE PATH "Paths to Torch libraries")
 
@@ -57,7 +57,7 @@ endif()
 
 set(TRITON_PYTORCH_DOCKER_BUILD OFF)
 if(TRITON_PYTORCH_LIB_PATHS STREQUAL "")
-  if (TRITON_PYTORCH_DOCKER_IMAGE)
+  if(TRITON_PYTORCH_DOCKER_IMAGE STREQUAL "")
     message(FATAL_ERROR "Using the PyTorch docker based build requires TRITON_PYTORCH_DOCKER_IMAGE")
   endif()
   set(TRITON_PYTORCH_DOCKER_BUILD ON)

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ Use a recent cmake to build. First install the required dependencies.
 $ apt-get install patchelf rapidjson-dev python3-dev
 ```
 
-Copy over the LibTorch and Torchvision headers and libraries from the
-[PyTorch NGC container](https://ngc.nvidia.com/catalog/containers/nvidia:pytorch)
-into local directories.
+An appropriate PyTorch container from [NGC](ngc.nvidia.com) must be used.
+For example, to build a backend that uses the 21.02 version of the PyTorch
+container from NGC:
 
 ```
 $ mkdir build
 $ cd build
-$ cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install -DTRITON_PYTORCH_INCLUDE_PATHS="/opt/tritonserver/include/torch;/opt/tritonserver/include/torch/torch/csrc/api/include;/opt/tritonserver/include/torchvision" -DTRITON_PYTORCH_LIB_PATHS="/opt/tritonserver/backends/pytorch"..
+$ cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install -DTRITON_PYTORCH_DOCKER_IMAGE="nvcr.io/nvidia/pytorch:21.02-py3" ..
 $ make install
 ```
 
@@ -73,3 +73,24 @@ but the listed CMake argument can be used to override.
 * triton-inference-server/backend: -DTRITON_BACKEND_REPO_TAG=[tag]
 * triton-inference-server/core: -DTRITON_CORE_REPO_TAG=[tag]
 * triton-inference-server/common: -DTRITON_COMMON_REPO_TAG=[tag]
+
+## Build the PyTorch Backend With Custom PyTorch
+
+Currently, Triton requires that a specially patched version of
+PyTorch be used with the PyTorch backend. The full source for
+these PyTorch versions are available as Docker images from
+[NGC](ngc.nvidia.com). For example, the PyTorch version
+compatible with the 21.02 release of Triton is available as
+nvcr.io/nvidia/pytorch:21.02-py3.
+
+Copy over the LibTorch and Torchvision headers and libraries from the
+[PyTorch NGC container](https://ngc.nvidia.com/catalog/containers/nvidia:pytorch)
+into local directories. You can see which headers and libraries
+are needed/copied from the docker. 
+
+```
+$ mkdir build
+$ cd build
+$ cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install -DTRITON_PYTORCH_INCLUDE_PATHS="<PATH_PREFIX>/torch;<PATH_PREFIX>/torch/torch/csrc/api/include;<PATH_PREFIX>/torchvision" -DTRITON_PYTORCH_LIB_PATHS="<LIB_PATH_PREFIX>" ..
+$ make install
+```


### PR DESCRIPTION
- User must always manually pass the TRITON_PYTORCH_DOCKER_IMAGE cmake flag
- Update Readme for NGC PyTorch container based build 