### PR TITLE
Fix timing for GPU execution

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -678,7 +678,7 @@ ModelInstanceState::ProcessRequests(
     // Attaching callback on the stream ensures correct timestamp
     // is captured.
     cudaLaunchHostFunc(
-        c10::cuda::getCurrentCUDAStream().stream(), TimestampCaptureCallback,
+        torch::cuda::getCurrentCUDAStream(), TimestampCaptureCallback,
         reinterpret_cast<void*>(&compute_end_ns));
   } else {
     SET_TIMESTAMP(compute_end_ns);

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -55,6 +55,18 @@
 
 namespace triton { namespace backend { namespace pytorch {
 
+namespace {
+
+#if defined(TRITON_ENABLE_GPU) && defined(TRITON_ENABLE_STATS)
+void CUDART_CB
+TimestampCaptureCallback(void* data)
+{
+  SET_TIMESTAMP(*(reinterpret_cast<uint64_t*>(data)));
+}
+#endif
+
+}  // namespace
+
 //
 // ModelState
 //
@@ -660,7 +672,14 @@ ModelInstanceState::ProcessRequests(
   Execute(&responses, request_count, &input_tensors, &output_tensors);
 
   uint64_t compute_end_ns = 0;
-  SET_TIMESTAMP(compute_end_ns);
+#if defined(TRITON_ENABLE_GPU) && defined(TRITON_ENABLE_STATS)
+  // For GPU, the Execute runs the inference asynchronously...
+  // Attaching callback on the stream ensures correct timestamp
+  // is captured.
+  cudaLaunchHostFunc(
+      CudaStream(), TimestampCaptureCallback,
+      reinterpret_cast<void*>(&compute_end_ns));
+#endif
 
   // Free BackendMemory used for inputs
   for (BackendMemory* mem : input_memories) {

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -677,7 +677,7 @@ ModelInstanceState::ProcessRequests(
   // Attaching callback on the stream ensures correct timestamp
   // is captured.
   cudaLaunchHostFunc(
-      CudaStream(), TimestampCaptureCallback,
+      c10::cuda::getCurrentCUDAStream().stream(), TimestampCaptureCallback,
       reinterpret_cast<void*>(&compute_end_ns));
 #endif
 


### PR DESCRIPTION
### Before 
`Avg request latency: 138887 usec (overhead 42 usec + queue 80 usec + compute input 13897 usec + compute infer 10288 usec + compute output 114580 usec)`

### After
`Avg request latency: 128321 usec (overhead 36 usec + queue 75 usec + compute input 20 usec + compute infer 128107 usec + compute output 83 usec)`
