### PR TITLE
Add support for disabling optimized execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,23 @@ $ cd build
 $ cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install -DTRITON_PYTORCH_INCLUDE_PATHS="<PATH_PREFIX>/torch;<PATH_PREFIX>/torch/torch/csrc/api/include;<PATH_PREFIX>/torchvision" -DTRITON_PYTORCH_LIB_PATHS="<LIB_PATH_PREFIX>" ..
 $ make install
 ```
+
+## Using the OpenVINO Backend
+
+### Parameters
+
+Disabling the optimized execution of the PyTorch models is done through the Parameters section of the model's 'config.pbtxt' file.
+
+* `DISABLE_OPTIMIZED_EXECUTION`: Boolean flag to disable the optimized execution of TorchScript models. By default the optimized execuiton is always enabled.
+
+The section of model config file specifying these parameters will look like:
+
+```
+parameters: {
+key: "DISABLE_OPTIMIZED_EXECUTION"
+    value: {
+    string_value:"true"
+    }
+}
+
+```

--- a/README.md
+++ b/README.md
@@ -95,13 +95,20 @@ $ cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install -DTRITON_PYTORCH_INCLUDE_PATHS
 $ make install
 ```
 
-## Using the OpenVINO Backend
+## Using the PyTorch Backend
 
 ### Parameters
 
 Disabling the optimized execution of the PyTorch models is done through the Parameters section of the model's 'config.pbtxt' file.
 
-* `DISABLE_OPTIMIZED_EXECUTION`: Boolean flag to disable the optimized execution of TorchScript models. By default the optimized execuiton is always enabled.
+* `DISABLE_OPTIMIZED_EXECUTION`: Boolean flag to disable the optimized execution
+of TorchScript models. By default the optimized execuiton is always enabled. 
+
+The initial calls to a loaded TorchScript model take extremely long. Due to this longer
+model warmup [issue](https://github.com/pytorch/pytorch/issues/57894), Triton also allows 
+execution of models without these optimizations. In some models, optimized execution 
+does not benefit performance as seen [here](https://github.com/pytorch/pytorch/issues/19978)
+and in other cases impacts performance negatively, as seen [here](https://github.com/pytorch/pytorch/issues/53824).
 
 The section of model config file specifying these parameters will look like:
 
@@ -112,5 +119,4 @@ key: "DISABLE_OPTIMIZED_EXECUTION"
     string_value:"true"
     }
 }
-
 ```

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-21 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -771,7 +771,7 @@ ModelInstanceState::Execute(
   torch::jit::IValue model_outputs_;
 
   try {
-    // enable/disable optimized exection
+    // enable/disable optimized execution
     torch::jit::setGraphExecutorOptimize(
         !model_state_->DisabledOptimizedExecution());
 

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -78,9 +78,16 @@ class ModelState : public BackendModel {
       std::string* model_path,
       std::unique_ptr<torch::jit::script::Module>* torch_model);
 
+  bool DisabledOptimizedExecution() { return disable_optimized_execution_; }
+
  private:
   ModelState(TRITONBACKEND_Model* triton_model);
   TRITONSERVER_Error* AutoCompleteConfig();
+
+  // Parses and validates parameters in config
+  TRITONSERVER_Error* ParseParameters();
+
+  bool disable_optimized_execution_;
 };
 
 
@@ -114,11 +121,13 @@ ModelState::Create(TRITONBACKEND_Model* triton_model, ModelState** state)
         triton_model, 1 /* config_version */, message));
   }
 
+  RETURN_IF_ERROR((*state)->ParseParameters());
+
   return nullptr;  // success
 }
 
 ModelState::ModelState(TRITONBACKEND_Model* triton_model)
-    : BackendModel(triton_model)
+    : BackendModel(triton_model), disable_optimized_execution_(false)
 {
 }
 
@@ -180,6 +189,23 @@ ModelState::AutoCompleteConfig()
   return nullptr;  // success
 }
 
+TRITONSERVER_Error*
+ModelState::ParseParameters()
+{
+  triton::common::TritonJson::Value params;
+  bool status = model_config_.Find("parameters", &params);
+  if (status) {
+    RETURN_IF_ERROR(ParseParameter(
+        params, "DISABLE_OPTIMIZED_EXECUTION", &disable_optimized_execution_));
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
+        ("Optimized execution is " +
+         (disable_optimized_execution_ ? "disabled" : "enabled"))
+            .c_str());
+  }
+
+  return nullptr;
+}
 
 //
 // ModelInstanceState
@@ -745,6 +771,10 @@ ModelInstanceState::Execute(
   torch::jit::IValue model_outputs_;
 
   try {
+    // enable/disable optimized exection
+    torch::jit::setGraphExecutorOptimize(
+        !model_state_->DisabledOptimizedExecution());
+
     torch::NoGradGuard no_grad;
     model_outputs_ = torch_model_->forward(*input_tensors);
     if (model_outputs_.isTuple()) {

--- a/src/libtorch_utils.cc
+++ b/src/libtorch_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -135,6 +135,18 @@ ModelConfigDataTypeToTorchType(const std::string& data_type_str)
   }
 
   return std::make_pair(true, type);
+}
+
+TRITONSERVER_Error*
+ParseParameter(
+    triton::common::TritonJson::Value& params, const std::string& mkey,
+    bool* value)
+{
+  std::string value_str;
+  RETURN_IF_ERROR(GetParameterValue(params, mkey, &value_str));
+  RETURN_IF_ERROR(ParseBoolValue(value_str, value));
+
+  return nullptr;
 }
 
 }}}  // namespace triton::backend::pytorch

--- a/src/libtorch_utils.cc
+++ b/src/libtorch_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-21 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/libtorch_utils.h
+++ b/src/libtorch_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "triton/backend/backend_common.h"
 #include "triton/core/tritonserver.h"
 
 // Suppress warnings in torch headers
@@ -53,5 +54,9 @@ std::pair<bool, torch::ScalarType> ConvertDataTypeToTorchType(
     const TRITONSERVER_DataType dtype);
 std::pair<bool, torch::ScalarType> ModelConfigDataTypeToTorchType(
     const std::string& data_type_str);
+
+TRITONSERVER_Error* ParseParameter(
+    triton::common::TritonJson::Value& params, const std::string& mkey,
+    bool* value);
 
 }}}  // namespace triton::backend::pytorch

--- a/src/libtorch_utils.h
+++ b/src/libtorch_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-21 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions


### PR DESCRIPTION
- specified in parameters in model config

Use a resnet50 model to verify if it works and here are the numbers
```
libtorch.cc:200] Optimized execution is disabled
First inference time (s): 1.056

libtorch.cc:200] Optimized execution is enabled
First inference time (s): 1.137

Speedup for first inference when optimized execution is disabled: 7% 
```

PS: Throughput is identical in both cases when using perf_analyzer