### PR TITLE
Add option to enable Cuda fuser (NvFuser) (#40)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -170,6 +170,7 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     COMMAND docker cp pytorch_backend_ptlib:/opt/pytorch/vision/build/libtorchvision.so libtorchvision.so
     COMMAND docker cp pytorch_backend_ptlib:/opt/pytorch/pytorch/LICENSE LICENSE.pytorch
     COMMAND docker cp pytorch_backend_ptlib:/opt/conda/lib/python3.8/site-packages/torch/include include/torch
+    COMMAND docker cp pytorch_backend_ptlib:/opt/pytorch/pytorch/torch/csrc/jit/codegen include/torch/torch/csrc/jit/codegen
     COMMAND docker cp pytorch_backend_ptlib:/opt/pytorch/vision/torchvision/csrc include/torchvision/torchvision
     COMMAND docker cp pytorch_backend_ptlib:/usr/lib/${LIBS_ARCH}-linux-gnu/libopencv_videoio.so.3.4.11 libopencv_videoio.so
     COMMAND docker cp pytorch_backend_ptlib:/usr/lib/${LIBS_ARCH}-linux-gnu/libopencv_highgui.so.3.4.11 libopencv_highgui.so

--- a/README.md
+++ b/README.md
@@ -144,6 +144,24 @@ key: "INFERENCE_MODE"
 }
 ```
 
+* `ENABLE_NVFUSER`: Boolean flag to enable the NvFuser (CUDA Graph Fuser) optimization for
+TorchScript models. If not specified, the default pytorch fuser is used. 
+
+Please note that in some models generated using trace in old PyTorch versions might not work
+correctly with NvFuser. We recommend using scripting and a recent version of PyTorch
+to generate these models.
+
+The section of model config file specifying this parameters will look like:
+
+```
+parameters: {
+key: "ENABLE_NVFUSER"
+    value: {
+    string_value:"true"
+    }
+}
+```
+
 ### Important Note
 
 * The execution of pytorch model on GPU is asynchronous in nature. See

--- a/src/libtorch_utils.h
+++ b/src/libtorch_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-21 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -33,6 +33,10 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma warning(push, 0)
+#include <torch/csrc/jit/codegen/cuda/interface.h>
+#include <torch/csrc/jit/codegen/fuser/interface.h>
+#include <torch/csrc/jit/passes/cuda_graph_fuser.h>
+#include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/script.h>  // One-stop header for TorchScript
 #pragma warning(pop)
 #pragma GCC diagnostic pop


### PR DESCRIPTION
* Enable nvfuser by default
- Add option to disable nvfuser

* Only use nvfuser when device is GPU

* Turn off nvfuser by default

* rename from disabble to enable nvfuser

* Make params variable naming consistent

* Update docs for NVFuser

* Must set nvfuser during model inference instead of model loading

* Do not call nvfuser apis if user not does explicitly set in model config

* Return pair as const

* Fix typo

* review edits

* Fix readme