### PR TITLE
add options for certain optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ key: "INFERENCE_MODE"
 ```
 
 * `ENABLE_NVFUSER`: Boolean flag to enable the NvFuser (CUDA Graph Fuser) optimization for
-TorchScript models. If not specified, the default pytorch fuser is used. 
+TorchScript models. If not specified, the default pytorch fuser is used.
+If `ENABLE_TENSOR_FUSER` is specified and _disabled_, the NvFuser configuration is ignored.
 
 Please note that in some models generated using trace in old PyTorch versions might not work
 correctly with NvFuser. We recommend using scripting and a recent version of PyTorch
@@ -170,7 +171,7 @@ complex execution modes and dynamic shapes. If not specified, all are enabled by
 
     `ENABLE_JIT_PROFILING`
 
-    `ENABLE_TORCH_TENSOR_FUSER`
+    `ENABLE_TENSOR_FUSER`
 
 ### Important Note
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ key: "ENABLE_NVFUSER"
 }
 ```
 
+* Additional Optimizations: Three additional boolean parameters are available to disable
+certain Torch optimizations that can sometimes cause latency regressions in models with
+complex execution modes and dynamic shapes. If not specified, all are enabled by default.
+
+    `ENABLE_JIT_EXECUTOR`
+
+    `ENABLE_JIT_PROFILING`
+
+    `ENABLE_TORCH_TENSOR_FUSER`
+
 ### Important Note
 
 * The execution of pytorch model on GPU is asynchronous in nature. See

--- a/src/libtorch_utils.h
+++ b/src/libtorch_utils.h
@@ -37,6 +37,7 @@
 #include <torch/csrc/jit/codegen/fuser/interface.h>
 #include <torch/csrc/jit/passes/cuda_graph_fuser.h>
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
+#include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/script.h>  // One-stop header for TorchScript
 #pragma warning(pop)
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Some models seem to perform poorly with the default set of JIT optimizations. Expose some of these API parameters in the config so that these models can be run in Triton.