### PR TITLE
Use tensor device instead of model device

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1165,6 +1165,9 @@ ModelInstanceState::ReadOutputTensors(
     const char* output_buffer =
         static_cast<const char*>(output_flat.data_ptr());
 
+    // Output tensors may not reside on the same device as model
+    torch::Device tensor_device = output_flat.device();
+
     //  Set output shape
     std::vector<int64_t> batchn_shape;
     auto shape = output_tensors[op_index].sizes();
@@ -1182,9 +1185,9 @@ ModelInstanceState::ReadOutputTensors(
 
     responder.ProcessTensor(
         name, output_dtype, batchn_shape, output_buffer,
-        (device_.type() == torch::kCPU) ? TRITONSERVER_MEMORY_CPU
-                                        : TRITONSERVER_MEMORY_GPU,
-        (device_.type() == torch::kCPU) ? 0 : device_.index());
+        (tensor_device.type() == torch::kCPU) ? TRITONSERVER_MEMORY_CPU
+                                              : TRITONSERVER_MEMORY_GPU,
+        (tensor_device.type() == torch::kCPU) ? 0 : tensor_device.index());
 
     // PyTorch uses asynchronous execution to run the model. Setting the compute
     // end timestamp immediately after Execute() does not capture the complete


### PR DESCRIPTION
- Some models outputs can be on a device different than the model itself

Error before:
```
pinned buffer: failed to perform CUDA copy: invalid argument
```

Fixes: https://github.com/triton-inference-server/server/issues/2641