### PR TITLE
Add support for passing inputs as a dictionary to model

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -611,6 +611,17 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_cnt)
       (arguments.at(start_idx).type()->kind() == c10::TypeKind::DictType)) {
     is_dict_input_ = true;
   } else if (arguments.size() > start_idx) {
+    // Return error if multiple inputs are of kind DictType
+    for (size_t i = start_idx + 1; i < arguments.size(); i++) {
+      if (arguments.at(i).type()->kind() == c10::TypeKind::DictType) {
+        return TRITONSERVER_ErrorNew(
+            TRITONSERVER_ERROR_INTERNAL,
+            "Multiple inputs of kind DictType were detected. Only a single "
+            "input of type Dict(str, Tensor) is supported.");
+      }
+    }
+
+    // Return error if all inputs are not of type Tensor
     for (size_t i = start_idx; i < arguments.size(); i++) {
       if (arguments.at(i).type()->kind() != c10::TypeKind::TensorType) {
         return TRITONSERVER_ErrorNew(

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -456,7 +456,7 @@ ModelInstanceState::Create(
 ModelInstanceState::ModelInstanceState(
     ModelState* model_state, TRITONBACKEND_ModelInstance* triton_model_instance)
     : BackendModelInstance(model_state, triton_model_instance),
-      model_state_(model_state), device_(torch::kCPU)
+      model_state_(model_state), device_(torch::kCPU), is_dict_input_(false)
 {
   if (Kind() == TRITONSERVER_INSTANCEGROUPKIND_GPU) {
     device_ = torch::Device(torch::kCUDA, DeviceId());

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1043,9 +1043,6 @@ ModelInstanceState::Execute(
       for (auto& input_index : input_index_map_) {
         torch::jit::IValue ival = (*input_tensors)[input_index.second];
         input_dict.insert(input_index.first, ival.toTensor());
-        LOG_MESSAGE(
-            TRITONSERVER_LOG_INFO,
-            (std::string("Input key: ") + input_index.first).c_str());
       }
       std::vector<torch::jit::IValue> input_dict_ivalue = {input_dict};
       model_outputs_ = torch_model_->forward(input_dict_ivalue);

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -596,9 +596,9 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_cnt)
   const auto& schema = method.function().getSchema();
   const std::vector<c10::Argument>& arguments = schema.arguments();
 
-  // Currently we only support input of type Dict[str, Tensor] when the
-  // model expects a single input. If the model expects more than one input then
-  // they must be all be of type Tensor.
+  // Currently, only models with a single input of type Dict(str, Tensor) are
+  // supported. If the model expects more than one input then they must be all
+  // be of type Tensor.
   //
   // Ignore the argument at idx 0 if it is of Class type (self param in forward
   // function)
@@ -615,8 +615,10 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_cnt)
       if (arguments.at(i).type()->kind() != c10::TypeKind::TensorType) {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INTERNAL,
-            "The model must expect a single input of type Dict[str, Tensor] "
-            "or one or more inputs of type Tensor.");
+            (std::string("An input of type '") + arguments.at(i).type()->str() +
+             "' was detected in the model. Only a single input of type "
+             "Dict(str, Tensor) or input(s) of type Tensor are supported.")
+                .c_str());
       }
     }
 


### PR DESCRIPTION
- Only works for when the model has 1 input type of kind DictType.
- For such a model the input names need not use the `name__index` convention. 
- The names of the inputs are used as the key for the input dictionary.


Sample error message:

```
+----------------------------------+---------+-----------------------------------------------------------------+
| Model                            | Version | Status                                                          |
+----------------------------------+---------+-----------------------------------------------------------------+
| libtorch_list_dict               | 1       | UNAVAILABLE: Internal: An input of type 'Dict(str, Tensor)[]' w |
|                                  |         | as detected in the model. Only a single input of type Dict(str, |
|                                  |         |  Tensor) or input(s) of type Tensor are supported.              |
+----------------------------------+---------+-----------------------------------------------------------------+
```