### PR TITLE
Allow input names from model metadata 

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -627,9 +627,6 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_cnt)
 
     // Return error if all inputs are not of type Tensor
     for (size_t i = start_idx; i < arguments.size(); i++) {
-      LOG_MESSAGE(
-          TRITONSERVER_LOG_INFO,
-          (std::string("Arguement Name: ") + arguments.at(i).name()).c_str());
       if (arguments.at(i).type()->kind() != c10::TypeKind::TensorType) {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INTERNAL,
@@ -1409,10 +1406,14 @@ TRITONBACKEND_ModelInstanceInitialize(TRITONBACKEND_ModelInstance* instance)
   int32_t device_id;
   RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceDeviceId(instance, &device_id));
 
+  TRITONSERVER_InstanceGroupKind kind;
+  RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceKind(instance, &kind));
+
   LOG_MESSAGE(
       TRITONSERVER_LOG_INFO,
-      (std::string("TRITONBACKEND_ModelInstanceInitialize: ") + name +
-       " (device " + std::to_string(device_id) + ")")
+      (std::string("TRITONBACKEND_ModelInstanceInitialize: ") + name + " (" +
+       TRITONSERVER_InstanceGroupKindString(kind) + " device " +
+       std::to_string(device_id) + ")")
           .c_str());
 
   // Get the model state associated with this instance's model.


### PR DESCRIPTION
- Allow input tensor names without naming convention when they match input argument names for forward function

Eg for the model below:

```
class Add(nn.Module):
    def __init__(self):
        super(Add, self).__init__()

    def forward(self, input0, input1):
        return input0 + input1
```

The input names (when not following the naming convention) would be **input0** and **input1**.

- Include device kind in logging of instance creation

Old:
```
libtorch.cc:1412] TRITONBACKEND_ModelInstanceInitialize: libtorch_float32_float32_float32 (device 0)
```
New: 
```
libtorch.cc:1412] TRITONBACKEND_ModelInstanceInitialize: libtorch_float32_float32_float32 (GPU device 0)
```