### PR TITLE
Share Model Weights for Instances on the Same Device

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ execution of models without these optimizations. In some models, optimized execu
 does not benefit performance as seen [here](https://github.com/pytorch/pytorch/issues/19978)
 and in other cases impacts performance negatively, as seen [here](https://github.com/pytorch/pytorch/issues/53824).
 
-The section of model config file specifying this parameters will look like:
+The section of model config file specifying this parameter will look like:
 
 ```
 parameters: {
@@ -133,7 +133,7 @@ this mode gets better performance by disabling autograd.
 Please note that in some models, InferenceMode might not benefit performance
 and in fewer cases might impact performance negatively.
 
-The section of model config file specifying this parameters will look like:
+The section of model config file specifying this parameter will look like:
 
 ```
 parameters: {
@@ -153,7 +153,7 @@ Please note that in some models generated using trace in old PyTorch versions mi
 correctly with NvFuser. We recommend using scripting and a recent version of PyTorch
 to generate these models.
 
-The section of model config file specifying this parameters will look like:
+The section of model config file specifying this parameter will look like:
 
 ```
 parameters: {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/README.md
+++ b/README.md
@@ -164,6 +164,21 @@ key: "ENABLE_NVFUSER"
 }
 ```
 
+* `ENABLE_WEIGHT_SHARING`: Boolean flag to enable model instances on the same device to
+share weights. This optimization should not be used with stateful models. If not specified,
+weight sharing is disabled.
+
+The section of model config file specifying this parameter will look like:
+
+```
+parameters: {
+key: "ENABLE_WEIGHT_SHARING"
+    value: {
+    string_value:"true"
+    }
+}
+```
+
 * Additional Optimizations: Three additional boolean parameters are available to disable
 certain Torch optimizations that can sometimes cause latency regressions in models with
 complex execution modes and dynamic shapes. If not specified, all are enabled by default.

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -545,8 +545,7 @@ ModelInstanceState::ModelInstanceState(
 
 ModelInstanceState::~ModelInstanceState()
 {
-  // If this is the last instance, remove the pointer from the map too to
-  // deallocate memory
+  // If this is the last instance, remove the pointer from the model map
   if (torch_model_.use_count() == 2) {
     if (StateForModel()->UnloadModel(
             std::make_pair(!device_.is_cpu(), device_.index())) != 1) {

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -227,7 +227,6 @@ ModelState::LoadModel(
     }
   }
 
-
   // Serialize the torch model to string
   std::string model_data_str;
   RETURN_IF_ERROR(ReadTextFile(*model_path, &model_data_str));
@@ -246,6 +245,7 @@ ModelState::LoadModel(
         TRITONSERVER_ERROR_INTERNAL,
         ("failed to load model '" + Name() + "': " + ex.what()).c_str());
   }
+
   if (enable_weight_sharing_) {
     if (!((torch_models_.emplace(device_pair, *torch_model)).second)) {
       std::string type = device.is_cpu() ? "CPU" : "GPU";

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -132,8 +132,8 @@ class ModelState : public BackendModel {
   // Defaults to (false, false).
   std::pair<bool, bool> enable_nvfuser_pair_;
 
-  // Share TorchScript model across all instances on the same device. The key
-  // is a pair of isGPU and device index.
+  // Model mapping for shared TorchScript model across all instances on the
+  // same device. The key is a pair of isGPU and device index.
   std::map<
       std::pair<bool, int64_t>, std::shared_ptr<torch::jit::script::Module>>
       torch_models_;

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -220,7 +220,7 @@ ModelState::LoadModel(
       *torch_model = mit->second;
       LOG_MESSAGE(
           TRITONSERVER_LOG_INFO,
-          (std::string("Re-using TorchScript model for instance '") + Name() +
+          (std::string("Reusing TorchScript model for instance '") + Name() +
            "'")
               .c_str());
       return nullptr;  // success

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -204,8 +204,7 @@ ModelState::LoadModel(
             "' for model instance '" + Name() + "'");
   }
 
-  // If torch model has already been been loaded on that device, skip loading
-  // that model Else load the model as usual
+  // Skip loading model if it is already available on the target device
   auto device_pair = std::make_pair(!device.is_cpu(), device.index());
   auto mit = torch_models_.find(device_pair);
   if (mit != torch_models_.end()) {


### PR DESCRIPTION
This PR allows a Triton user to enable multiple instances of a model on the same device to share weights. This is turned off by default and can be enabled via a model config parameter, "ENABLE_WEIGHT_SHARING."

Enabling weight reuse can reduce memory usage of model loading and inference. It should not be used with models that maintain state (due to the reusing of weights).

Related server test change: https://github.com/triton-inference-server/server/pull/4123