### PR TITLE
Remove __<index> from tensor name for dict input

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1159,7 +1159,14 @@ ModelInstanceState::Execute(
       torch::Dict<std::string, torch::Tensor> input_dict;
       for (auto& input_index : input_index_map_) {
         torch::jit::IValue ival = (*input_tensors)[input_index.second];
-        input_dict.insert(input_index.first, ival.toTensor());
+        std::string tensor_name = input_index.first;
+        std::string deliminator = "__";
+        int start_pos = tensor_name.find(deliminator);
+        if (start_pos == -1) {
+          input_dict.insert(tensor_name, ival.toTensor());
+        } else {
+          input_dict.insert(tensor_name.substr(0, start_pos), ival.toTensor());
+        }
       }
       std::vector<torch::jit::IValue> input_dict_ivalue = {input_dict};
       model_outputs_ = torch_model_->forward(input_dict_ivalue);


### PR DESCRIPTION
background:

For forward() with a dictionary, if we append __<index>  to input feature xyz, one will get feature xyz is not found in pytorch eval. If we removed __<index> in input spec of config.pbtxt and run python client without __<index>, the inference works.

However, when updating config.pbtxt for model with forward() using feature list, will get error during model loading.

When loading the model, we don't know if it is using dictionary or feature list. It seems the input handling is not consistent. 

This PR is to remove the __<index> from name.