### PR TITLE
Add support for String input/output

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ complex execution modes and dynamic shapes. If not specified, all are enabled by
   configuration may help in some cases to avoid these negative interactions
   due to model specific caching and increase multiple instance performance.
 
-* Since PyTorch does not support Tensor of Strings, Triton allows users to pass
-string input(s)/recieve string output(s) using a List of Strings. Because of using
-List instead of Tensor, string I/O is supported only for 1-dimensional inputs/outputs.
+* PyTorch does not support Tensor of Strings but it does support models that accept
+a List of Strings as input(s) / produces a List of String as output(s). For these models
+Triton allows users to pass String input(s)/recieve String output(s) using the String
+datatype. As a limitation of using List instead of Tensor for String I/O, only for
+1-dimensional input(s)/output(s) are supported for I/O of String type.
 This means batching must be disabled as well for String I/O on TorchScript models.

--- a/README.md
+++ b/README.md
@@ -210,6 +210,6 @@ complex execution modes and dynamic shapes. If not specified, all are enabled by
   due to model specific caching and increase multiple instance performance.
 
 * Since PyTorch does not support Tensor of Strings, Triton allows users to pass
-string input/recieve string output using a List of Strings. Because of using List
-instead of Tensor, string I/O only is supported only for 1 dimension. This means
-that the `shape` must a single dimension and batching must be disabled as well.
+string input(s)/recieve string output(s) using a List of Strings. Because of using
+List instead of Tensor, string I/O is supported only for 1-dimensional inputs/outputs.
+This means batching must be disabled as well for String I/O on TorchScript models.

--- a/README.md
+++ b/README.md
@@ -214,4 +214,5 @@ a List of Strings as input(s) / produces a List of String as output(s). For thes
 Triton allows users to pass String input(s)/recieve String output(s) using the String
 datatype. As a limitation of using List instead of Tensor for String I/O, only for
 1-dimensional input(s)/output(s) are supported for I/O of String type.
-This means batching must be disabled as well for String I/O on TorchScript models.
+Batching is not allowed for PyTorch models with String I/O. For these models,
+the user must specify `max_batch_size: 0` in the configuration.

--- a/README.md
+++ b/README.md
@@ -208,3 +208,8 @@ complex execution modes and dynamic shapes. If not specified, all are enabled by
   Setting the parameter `DISABLE_OPTIMIZED_EXECUTION` to "true" in the model
   configuration may help in some cases to avoid these negative interactions
   due to model specific caching and increase multiple instance performance.
+
+* Since PyTorch does not support Tensor of Strings, Triton allows users to pass
+string input/recieve string output using a List of Strings. Because of using List
+instead of Tensor, string I/O only is supported only for 1 dimension. This means
+that the `shape` must a single dimension and batching must be disabled as well.

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1277,7 +1277,8 @@ FillStringTensor(
     torch::List<std::string>* input_list, const size_t idx, const size_t cnt)
 {
   for (size_t c = 0; c < cnt; ++c) {
-    (*input_list)[idx + c] = std::string(nullptr, 0);
+    input_list->push_back("");
+    // (*input_list)[idx + c] = "";
   }
 }
 
@@ -1362,8 +1363,24 @@ SetStringInputTensor(
       return cuda_copy;
     }
 
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
+        (std::string("len: ") + std::to_string(len)).c_str());
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
+        (std::string("tensor_offset: ") + std::to_string(tensor_offset))
+            .c_str());
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
+        (std::string("element_idx: ") + std::to_string(element_idx)).c_str());
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO, (std::string("std::string(content, len): '") +
+                                std::string(content, len) + "'")
+                                   .c_str());
+
     // Set string value
-    (*input_list)[tensor_offset + element_idx] = std::string(content, len);
+    input_list->push_back(std::string(content, len));
+    // (*input_list)[tensor_offset + element_idx] = std::string(content, len);
 
     content += len;
     content_byte_size -= len;

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1230,12 +1230,13 @@ ModelInstanceState::Execute(
             throw std::invalid_argument(
                 "output at index " + std::to_string(op_index) +
                 " must be of type Tensor or List[str], recieved List[" +
-                output_list.elementType()->str() + "]");
+                list_output.elementType()->str() + "]");
           }
           output_tensors->push_back(m_op);
-        } else
-          auto tensor_output = m_op.isTensor();
-        output_tensors->push_back(m_op);
+        } else {
+          auto tensor_output = m_op.toTensor();
+          output_tensors->push_back(m_op);
+        }
         op_index++;
       }
     } else if (model_outputs_.isTensor()) {
@@ -1245,7 +1246,7 @@ ModelInstanceState::Execute(
       if (list_output.elementType()->kind() != c10::TypeKind::StringType) {
         throw std::invalid_argument(
             "output must be of type Tensor or List[str], recieved List[" +
-            output_list.elementType()->str() + "]");
+            list_output.elementType()->str() + "]");
       }
       output_tensors->push_back(model_outputs_);
     } else {

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -779,7 +779,7 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_cnt)
 
     // Validate shape for String inputs. Only allow 1 dimension and no
     // batching.
-    if (io_dtype != "TYPE_STRING") {
+    if (io_dtype == "TYPE_STRING") {
       // If a reshape is provided for the input then use that when
       // validating the model shapes.
       std::vector<int64_t> dims;
@@ -820,7 +820,7 @@ ModelInstanceState::ValidateOutputs()
         "specified.");
   }
 
-  bool supports_batching = model_state_->MaxBatchSize() > 0;
+  const bool supports_batching = model_state_->MaxBatchSize() > 0;
 
   for (size_t i = 0; i < ios.ArraySize(); i++) {
     triton::common::TritonJson::Value io;
@@ -858,7 +858,7 @@ ModelInstanceState::ValidateOutputs()
 
     // Validate shape for String outputs. Only allow 1 dimension and no
     // batching.
-    if (io_dtype != "TYPE_STRING") {
+    if (io_dtype == "TYPE_STRING") {
       // If a reshape is provided for the output then use that when
       // validating the model shapes.
       std::vector<int64_t> dims;

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1170,14 +1170,10 @@ ModelInstanceState::Execute(
     if (model_outputs_.isTuple()) {
       auto model_outputs_tuple = model_outputs_.toTuple();
       for (auto& m_op : model_outputs_tuple->elements()) {
-        // if (m_op.isList()) {
-        // }
         output_tensors->push_back(m_op);
-        // output_tensors->push_back(m_op.toTensor());
       }
     } else {
       try {
-        // auto model_output_tensor = model_outputs_.toTensor();
         output_tensors->push_back(model_outputs_);
       }
       catch (std::exception& exx) {
@@ -1278,7 +1274,6 @@ FillStringTensor(
 {
   for (size_t c = 0; c < cnt; ++c) {
     input_list->push_back("");
-    // (*input_list)[idx + c] = "";
   }
 }
 
@@ -1363,24 +1358,8 @@ SetStringInputTensor(
       return cuda_copy;
     }
 
-    LOG_MESSAGE(
-        TRITONSERVER_LOG_INFO,
-        (std::string("len: ") + std::to_string(len)).c_str());
-    LOG_MESSAGE(
-        TRITONSERVER_LOG_INFO,
-        (std::string("tensor_offset: ") + std::to_string(tensor_offset))
-            .c_str());
-    LOG_MESSAGE(
-        TRITONSERVER_LOG_INFO,
-        (std::string("element_idx: ") + std::to_string(element_idx)).c_str());
-    LOG_MESSAGE(
-        TRITONSERVER_LOG_INFO, (std::string("std::string(content, len): '") +
-                                std::string(content, len) + "'")
-                                   .c_str());
-
     // Set string value
     input_list->push_back(std::string(content, len));
-    // (*input_list)[tensor_offset + element_idx] = std::string(content, len);
 
     content += len;
     content_byte_size -= len;
@@ -1418,7 +1397,6 @@ SetStringOutputBuffer(
   // null-terminator.
   serialized->clear();
   for (size_t e = 0; e < tensor_element_count; ++e) {
-    // size_t len;
     std::string str = tensor->get(e).to<std::string>();
     const char* cstr = str.c_str();
     size_t len = str.length();


### PR DESCRIPTION
- PyTorch does not natively support tensors of string
- We allow users to pass a list of type string instead. For now we allow only 1D lists of strings. This means that batching for string I/O is not supported.

TODO 
- [x] Add model generation and test coverage for addsub and identity models for string I/O  