### PR TITLE
Enforce ordering of I/O if naming convention is not followed

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1343,7 +1343,8 @@ ModelInstanceState::GetNamingConvention(
           throw std::invalid_argument(
               "input/output must follow naming convention");
         }
-        io_index = std::atoi(io_name.substr(start_pos + 2).c_str());
+        // Use atoi to check if the index part of the name is an integer
+        std::atoi(io_name.substr(start_pos + 2).c_str());
       }
       catch (std::exception& ex) {
         if (io_kind == "input") {

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -425,10 +425,10 @@ ModelState::ParseParameters()
 }
 
 // The naming convention followed for inputs/outputs in the model configuration.
-// Outputs don't support ARGUEMENT.
+// Outputs don't support FORWARD_ARGUMENT.
 enum class NamingConvention {
   NAMED_INDEX,
-  FORWARD_ARGUEMENT,
+  FORWARD_ARGUMENT,
   STRICT_CONFIG_ORDERING
 };
 
@@ -756,7 +756,7 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_cnt)
       input_index_map_[io_name] = i;
     } else {
       switch (naming_convention) {
-        case NamingConvention::FORWARD_ARGUEMENT: {
+        case NamingConvention::FORWARD_ARGUMENT: {
           auto itr = allowed_inputs.find(io_name);
           if (itr != allowed_inputs.end()) {
             input_index_map_[io_name] =
@@ -1301,7 +1301,7 @@ ModelInstanceState::GetNamingConvention(
   std::string deliminator = "__";
   size_t io_index = 0;
   std::string io_kind = "input";
-  *naming_convention = NamingConvention::FORWARD_ARGUEMENT;
+  *naming_convention = NamingConvention::FORWARD_ARGUMENT;
   if (allowed_ios.size() == 0) {
     // symbolizes output
     io_kind = "output";


### PR DESCRIPTION
- Add fall back to enforcing ordering of inputs/outputs for cases when neither naming convention for I/O is met i.e. not an input argument in the model forward function and not using the <name>__<index> format for names.
- These models that failed to follow the naming conventions would earlier fail to load. Now they load successfully and the input/outputs assume the order they are specified in inside the model configuration file.

