### PR TITLE
Fix possible "double send" of responses.

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1223,21 +1223,21 @@ ModelInstanceState::ProcessRequests(
 #ifdef TRITON_ENABLE_GPU
     float compute_input_duration = 0;
     float compute_infer_duration = 0;
-    RESPOND_ALL_AND_SET_TRUE_IF_ERROR(
-        responses, request_count, all_response_failed,
+    LOG_IF_ERROR(
         ConvertCUDAStatusToTritonError(
             cudaEventElapsedTime(
                 &compute_input_duration, compute_input_start_event_,
                 compute_infer_start_event_),
-            TRITONSERVER_ERROR_INTERNAL, "Failed to capture elapsed time"));
+            TRITONSERVER_ERROR_INTERNAL, "Failed to capture elapsed time"),
+            "Failed to capture elapsed time");
 
-    RESPOND_ALL_AND_SET_TRUE_IF_ERROR(
-        responses, request_count, all_response_failed,
+    LOG_IF_ERROR(
         ConvertCUDAStatusToTritonError(
             cudaEventElapsedTime(
                 &compute_infer_duration, compute_infer_start_event_,
                 compute_output_start_event_),
-            TRITONSERVER_ERROR_INTERNAL, "Failed to capture elapsed time"));
+            TRITONSERVER_ERROR_INTERNAL, "Failed to capture elapsed time"),
+            "Failed to capture elapsed time");
 
     compute_start_ns = exec_start_ns + (compute_input_duration * 1e6);
     compute_end_ns = compute_start_ns + (compute_infer_duration * 1e6);

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1221,6 +1221,8 @@ ModelInstanceState::ProcessRequests(
   // synchronized the stream in the ReadOutputTensors function.
   if (Kind() == TRITONSERVER_INSTANCEGROUPKIND_GPU) {
 #ifdef TRITON_ENABLE_GPU
+    // [FIXME] in the case of cudaEventElapsedTime failure, should handle
+    // stats reporting more gracefully as the durations are inaccurate
     float compute_input_duration = 0;
     float compute_infer_duration = 0;
     LOG_IF_ERROR(


### PR DESCRIPTION
By this point, the responses are sent but we keep the pointer reference to identify if the request are processed successfully for `TRITONBACKEND_ModelInstanceReportStatistics`. As a result, `RESPOND_ALL_AND_SET_TRUE_IF_ERROR` may send a response twice and cause memory corruption.