### PR TITLE
re-enable nvfuser

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -432,7 +432,6 @@ ModelState::ParseParameters()
               .c_str());
     }
 
-    // TODO Re-enable NvFuser once fixed
     // If 'ENABLE_NVFUSER' is not present in 'parameters' then no
     // update is made to 'enable_nvfuser'.
     bool enable_nvfuser = false;
@@ -448,8 +447,6 @@ ModelState::ParseParameters()
         TRITONSERVER_ErrorDelete(err);
       }
     } else {
-      // Override, disable NvFuser till fixed
-      enable_nvfuser = false;
       enable_nvfuser_pair_ = {true, enable_nvfuser};
       LOG_MESSAGE(
           TRITONSERVER_LOG_WARN, (std::string("NvFuser is ") +

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -449,7 +449,7 @@ ModelState::ParseParameters()
     } else {
       enable_nvfuser_pair_ = {true, enable_nvfuser};
       LOG_MESSAGE(
-          TRITONSERVER_LOG_WARN, (std::string("NvFuser is ") +
+          TRITONSERVER_LOG_INFO, (std::string("NvFuser is ") +
                                   (enable_nvfuser ? "enabled" : "disabled") +
                                   " for model instance '" + Name() + "'")
                                      .c_str());
@@ -1228,7 +1228,7 @@ ModelInstanceState::ProcessRequests(
                 &compute_input_duration, compute_input_start_event_,
                 compute_infer_start_event_),
             TRITONSERVER_ERROR_INTERNAL, "Failed to capture elapsed time"),
-            "Failed to capture elapsed time");
+        "Failed to capture elapsed time");
 
     LOG_IF_ERROR(
         ConvertCUDAStatusToTritonError(
@@ -1236,7 +1236,7 @@ ModelInstanceState::ProcessRequests(
                 &compute_infer_duration, compute_infer_start_event_,
                 compute_output_start_event_),
             TRITONSERVER_ERROR_INTERNAL, "Failed to capture elapsed time"),
-            "Failed to capture elapsed time");
+        "Failed to capture elapsed time");
 
     compute_start_ns = exec_start_ns + (compute_input_duration * 1e6);
     compute_end_ns = compute_start_ns + (compute_infer_duration * 1e6);


### PR DESCRIPTION
The only thing I notice is this deprecation warning, which I figure we can fix in the future if there's a problem with the old API we're using:
> [W cuda_graph_fuser.h:17] Warning: RegisterCudaFuseGraph::registerPass() is deprecated. Please use torch::jit::fuser::cuda::setEnabled(). (function registerPass)

Fixes https://github.com/triton-inference-server/server/issues/5128