### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1312,12 +1312,12 @@ ModelInstanceState::Execute(
         torch::jit::overrideCanFuseOnCPU(false);
         torch::jit::overrideCanFuseOnGPU(false);
         torch::jit::setTensorExprFuserEnabled(false);
-        torch::jit::RegisterCudaFuseGraph::registerPass(true);
+	torch::jit::fuser::cuda::setEnabled(true);
       } else {
         torch::jit::overrideCanFuseOnCPU(true);
         torch::jit::overrideCanFuseOnGPU(true);
         torch::jit::setTensorExprFuserEnabled(true);
-        torch::jit::RegisterCudaFuseGraph::registerPass(false);
+	torch::jit::fuser::cuda::setEnabled(false);
       }
     }
 


### PR DESCRIPTION
Fixing warning: 
[W cuda_graph_fuser.h:17] Warning: RegisterCudaFuseGraph::registerPass() is deprecated. Please use torch::jit::fuser::cuda::setEnabled(). (function registerPass)