### PR TITLE
Add support for instance group of type 'MODEL'

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -2004,7 +2004,10 @@ ModelInstanceState::SetInputTensors(
 
     // The input must be in contiguous CPU/GPU memory.
     std::vector<std::pair<TRITONSERVER_MemoryType, int64_t>> alloc_perference;
-    if (device_.is_cpu()) {
+    // For 'KIND_MODEL', intput will always be in CPU as we don't have a way to
+    // query the input types.
+    if ((device_.is_cpu()) ||
+        (Kind() == TRITONSERVER_INSTANCEGROUPKIND_MODEL)) {
       alloc_perference = {{TRITONSERVER_MEMORY_CPU_PINNED, 0},
                           {TRITONSERVER_MEMORY_CPU, 0}};
     } else {

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -660,7 +660,14 @@ ModelInstanceState::ModelInstanceState(
 
   if (Kind() == TRITONSERVER_INSTANCEGROUPKIND_MODEL) {
 #ifdef TRITON_ENABLE_GPU
-    // Create a CUDA stream for every availble device.
+    // Since we cannot determine the exact devices used by the model, we create
+    // a CUDA stream for every available device to ensure proper synchronization
+    // of CUDA streams. This approach may have implications when a timestamp is
+    // captured on a device that is not used by the model. Currently, this issue
+    // is addressed by synchronizing the CUDA streams before recording
+    // timestamps to prevent timestamp skewing. However, in the future, any
+    // modifications to the CUDA stream synchronization logic should be handled
+    // with caution.
     for (int i = 0; i < torch::cuda::device_count(); i++) {
       cudaStream_t stream;
       THROW_IF_BACKEND_INSTANCE_ERROR(

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1305,7 +1305,7 @@ ModelInstanceState::ProcessRequests(
   }
 
   uint64_t compute_end_ns = 0;
-  std::atomic<uint64_t> compute_output_start = 0;
+  std::atomic<uint64_t> compute_output_start{0};
 
   if ((Kind() == TRITONSERVER_INSTANCEGROUPKIND_MODEL) && (device_cnt_ > 0)) {
 #ifdef TRITON_ENABLE_GPU

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -65,7 +65,7 @@ namespace {
 
 #ifdef TRITON_ENABLE_GPU
 void CUDART_CB
-CaptureLastTimestampCallback(void* data)
+CaptureTimestampCallback(void* data)
 {
   auto* timestamp = reinterpret_cast<std::atomic<uint64_t>*>(data);
   SET_TIMESTAMP(*timestamp);
@@ -1312,7 +1312,7 @@ ModelInstanceState::ProcessRequests(
     // For the compute infer duration, multiple streams will be involved, so we
     // need to launch a CUDA callback function for timestamp capturing.
     cudaLaunchHostFunc(
-        GetCudaStreamByInstanceKind(), CaptureLastTimestampCallback,
+        GetCudaStreamByInstanceKind(), CaptureTimestampCallback,
         reinterpret_cast<void*>(&compute_output_start));
 #endif
   } else {

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -2282,6 +2282,7 @@ void
 ModelInstanceState::SetCurrentCudaStream(
     const cudaStream_t& stream, const int& device_id)
 {
+#ifdef TRITON_ENABLE_GPU
   at::cuda::CUDAStream torch_stream =
       at::cuda::getStreamFromExternal(stream, device_id);
   // This function replaces the default stream with the stream we created. It
@@ -2289,6 +2290,7 @@ ModelInstanceState::SetCurrentCudaStream(
   // replacing the default stream for that device. See the documentation here:
   // https://pytorch.org/cppdocs/api/function_namespacec10_1_1cuda_1a6ed50cc0fc16cc7014d9c2f4c3bd098d.html
   at::cuda::setCurrentCUDAStream(torch_stream);
+#endif
 }
 
 /////////////

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -80,7 +80,7 @@ class ModelState : public BackendModel {
   // representing the model.
   TRITONSERVER_Error* LoadModel(
       const std::string& artifact_name, const torch::Device device,
-      std::string* model_path,
+      std::string* model_path, const TRITONSERVER_InstanceGroupKind& kind,
       std::shared_ptr<torch::jit::script::Module>* torch_model);
 
   bool EnabledOptimizedExecution() { return enable_optimized_execution_; }
@@ -205,7 +205,7 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
 TRITONSERVER_Error*
 ModelState::LoadModel(
     const std::string& artifact_name, const torch::Device device,
-    std::string* model_path,
+    std::string* model_path,  const TRITONSERVER_InstanceGroupKind& kind,
     std::shared_ptr<torch::jit::script::Module>* torch_model)
 {
   // Find the TorchScript file that describes the model. If the model
@@ -255,8 +255,14 @@ ModelState::LoadModel(
 
   try {
     std::istringstream model_stream(model_data_str);
-    torch_model->reset(
-        new torch::jit::Module(torch::jit::load(model_stream, device)));
+    if (kind == TRITONSERVER_INSTANCEGROUPKIND_MODEL) {
+      // Don't select the device when loading the model.
+      torch_model->reset(
+        new torch::jit::Module(torch::jit::load(model_stream)));
+    } else {
+      torch_model->reset(
+          new torch::jit::Module(torch::jit::load(model_stream, device)));
+    }
   }
   catch (const std::exception& ex) {
     return TRITONSERVER_ErrorNew(
@@ -606,7 +612,7 @@ ModelInstanceState::ModelInstanceState(
   }
 
   THROW_IF_BACKEND_INSTANCE_ERROR(model_state->LoadModel(
-      ArtifactFilename(), device_, &model_path_, &torch_model_));
+      ArtifactFilename(), device_, &model_path_, Kind(), &torch_model_));
 
   size_t expected_input_cnt = 0;
   {

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -2241,17 +2241,17 @@ float
 ModelInstanceState::GetCudaEventElapsedTime(
     const cudaEvent_t& start_event, const cudaEvent_t& end_event)
 {
+  float duration = 0;
 #ifdef TRITON_ENABLE_GPU
   // [FIXME] in the case of cudaEventElapsedTime failure, should handle
   // stats reporting more gracefully as the durations are inaccurate
-  float duration = 0;
   LOG_IF_ERROR(
       ConvertCUDAStatusToTritonError(
           cudaEventElapsedTime(&duration, start_event, end_event),
           TRITONSERVER_ERROR_INTERNAL, "Failed to capture elapsed time"),
       "Failed to capture elapsed time");
-  return duration;
 #endif
+  return duration;
 }
 
 /////////////

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -205,7 +205,7 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
 TRITONSERVER_Error*
 ModelState::LoadModel(
     const std::string& artifact_name, const torch::Device device,
-    std::string* model_path,  const TRITONSERVER_InstanceGroupKind& kind,
+    std::string* model_path, const TRITONSERVER_InstanceGroupKind& kind,
     std::shared_ptr<torch::jit::script::Module>* torch_model)
 {
   // Find the TorchScript file that describes the model. If the model
@@ -258,7 +258,7 @@ ModelState::LoadModel(
     if (kind == TRITONSERVER_INSTANCEGROUPKIND_MODEL) {
       // Don't select the device when loading the model.
       torch_model->reset(
-        new torch::jit::Module(torch::jit::load(model_stream)));
+          new torch::jit::Module(torch::jit::load(model_stream)));
     } else {
       torch_model->reset(
           new torch::jit::Module(torch::jit::load(model_stream, device)));


### PR DESCRIPTION
For `MODEL` instance group type,
- Don't specify the device when loading the model so that the backend will not select the device for the model
- For the compute input duration, since only one stream will be used for input collection, we can record the cuda events to calculate the elapsed time. However, for the compute infer duration, since multiple streams will be involved, it is hard to use cuda events as timestamps. Therefore, using `cudaLaunchHostFunc` to launch a callback function to record the timestamp.

Added testing: https://github.com/triton-inference-server/server/pull/5810
Closes: https://github.com/triton-inference-server/server/issues/5694