### PR TITLE
Copy HPCX paths for CPU images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,14 +202,14 @@ if(NOT TRITON_ENABLE_GPU)
     OUTPUT
       ${HPCX_LIBS}
     COMMAND docker pull ${TRITON_PYTORCH_DOCKER_IMAGE}
-    COMMAND docker rm pytorch_backend_ptlib || echo "error ignored..." || true
-    COMMAND docker create --name pytorch_backend_ptlib ${TRITON_PYTORCH_DOCKER_IMAGE}
-    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucc/lib/libucc.so.1 libucc.so.1
-    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucm.so.0 libucm.so.0
-    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucp.so.0 libucp.so.0
-    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucs.so.0 libucs.so.0
-    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libuct.so.0 libuct.so.0
-    COMMAND docker rm pytorch_backend_ptlib
+    COMMAND docker rm pytorch_backend_hpcxlib || echo "error ignored..." || true
+    COMMAND docker create --name pytorch_backend_hpcxlib ${TRITON_PYTORCH_DOCKER_IMAGE}
+    COMMAND docker cp -L pytorch_backend_hpcxlib:/opt/hpcx/ucc/lib/libucc.so.1 libucc.so.1
+    COMMAND docker cp -L pytorch_backend_hpcxlib:/opt/hpcx/ucx/lib/libucm.so.0 libucm.so.0
+    COMMAND docker cp -L pytorch_backend_hpcxlib:/opt/hpcx/ucx/lib/libucp.so.0 libucp.so.0
+    COMMAND docker cp -L pytorch_backend_hpcxlib:/opt/hpcx/ucx/lib/libucs.so.0 libucs.so.0
+    COMMAND docker cp -L pytorch_backend_hpcxlib:/opt/hpcx/ucx/lib/libuct.so.0 libuct.so.0
+    COMMAND docker rm pytorch_backend_hpcxlib
     VERBATIM
   )
 endif() # TRITON_ENABLE_GPU

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ endif() # TRITON_PYTORCH_DOCKER_BUILD
 install(
       CODE
         "EXECUTE_PROCESS(
-          COMMAND patchelf --set-rpath $ORIGIN:/opt/hpcx/ucx/lib/ libtorch.so
+          COMMAND patchelf --set-rpath $ORIGIN:/opt/hpcx/ucx/lib/ libtorch.so && /sbin/ldconfig
           RESULT_VARIABLE PATCHELF_STATUS
           WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
         if(PATCHELF_STATUS AND NOT PATCHELF_STATUS EQUAL 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,9 +210,7 @@ if(NOT TRITON_ENABLE_GPU)
     COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucp.so.0 libucp.so.0
     COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucs.so.0 libucs.so.0
     COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libuct.so.0 libuct.so.0
-    COMMAND ls -la .
     COMMAND docker rm pytorch_backend_ptlib
-    COMMENT "Extracting HPCX libraries from ${TRITON_PYTORCH_DOCKER_IMAGE}"
     VERBATIM
   )
 endif() # TRITON_ENABLE_GPU

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,11 +139,6 @@ set(PT_LIBS
     "libtorch_cuda_linalg.so"
     "libtorch_global_deps.so"
     "libnvfuser_codegen.so"
-    "libucc.so.1"
-    "libucm.so.0"
-    "libucp.so.0"
-    "libucs.so.0"
-    "libuct.so.0"
 )
 
 if (${TRITON_PYTORCH_ENABLE_TORCHVISION})
@@ -194,6 +189,34 @@ set(OPENCV_LIBS
     "libjpeg.so"
 )
 
+# In CPU-only mode, get the hpcx libraries neededby libtorch.so.
+if(NOT TRITON_ENABLE_GPU)
+  set(HPCX_LIBS
+      "libucc.so.1"
+      "libucm.so.0"
+      "libucp.so.0"
+      "libucs.so.0"
+      "libuct.so.0"
+  )
+  add_custom_command(
+    OUTPUT
+      ${HPCX_LIBS}
+    # COMMAND docker pull ${TRITON_PYTORCH_DOCKER_IMAGE}
+    COMMAND docker rm pytorch_backend_ptlib || echo "error ignored..." || true
+    COMMAND echo "Running ${TRITON_PYTORCH_DOCKER_IMAGE} to extract HPCX libraries"
+    COMMAND docker create --name pytorch_backend_ptlib ${TRITON_PYTORCH_DOCKER_IMAGE}
+    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucc/lib/libucc.so.1 libucc.so.1
+    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucm.so.0 libucm.so.0
+    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucp.so.0 libucp.so.0
+    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucs.so.0 libucs.so.0
+    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libuct.so.0 libuct.so.0
+    COMMAND ls -la .
+    COMMAND docker rm pytorch_backend_ptlib
+    COMMENT "Extracting HPCX libraries from ${TRITON_PYTORCH_DOCKER_IMAGE}"
+    VERBATIM
+  )
+endif() # TRITON_ENABLE_GPU
+
 # The patchelf commands ensure the MKL libraries are loaded correctly during runtime
 # Without these, the framework/backend complains of missing libraries / symbols and 
 # in some cases leads to segmentation faults.
@@ -238,11 +261,6 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     COMMAND docker cp -L pytorch_backend_ptlib:/usr/local/lib/libopencv_calib3d.so libopencv_calib3d.so
     COMMAND docker cp -L pytorch_backend_ptlib:/usr/local/lib/libopencv_features2d.so libopencv_features2d.so
     COMMAND docker cp -L pytorch_backend_ptlib:/usr/local/lib/libopencv_flann.so libopencv_flann.so
-    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucc/lib/libucc.so.1 libucc.so.1
-    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucm.so.0 libucm.so.0
-    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucp.so.0 libucp.so.0
-    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucs.so.0 libucs.so.0
-    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libuct.so.0 libuct.so.0
     COMMAND docker cp pytorch_backend_ptlib:/usr/lib/${LIBS_ARCH}-linux-gnu/libpng16.so.16.37.0 libpng16.so
     COMMAND docker cp pytorch_backend_ptlib:/usr/lib/${LIBS_ARCH}-linux-gnu/libjpeg.so.8.2.2 libjpeg.so
     COMMAND /bin/sh -c "if [ -f libmkl_def.so.1 ]; then patchelf --add-needed libmkl_gnu_thread.so.1 libmkl_def.so.1; fi"
@@ -259,7 +277,8 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     COMMENT "Extracting pytorch and torchvision libraries and includes from ${TRITON_PYTORCH_DOCKER_IMAGE}"
     VERBATIM
   )
-add_custom_target(ptlib_target DEPENDS ${PT_LIBS} ${LIBTORCH_LIBS} ${OPENCV_LIBS})
+  message(STATUS "hpcx libs: ${HPCX_LIBS}")
+  add_custom_target(ptlib_target DEPENDS ${PT_LIBS} ${HPCX_LIBS} ${LIBTORCH_LIBS} ${OPENCV_LIBS})
   add_library(ptlib SHARED IMPORTED GLOBAL)
   add_dependencies(ptlib ptlib_target)
 
@@ -425,7 +444,7 @@ install(
 
 if (${TRITON_PYTORCH_DOCKER_BUILD})
   set(PT_LIB_PATHS "")
-  FOREACH(plib ${PT_LIBS} ${LIBTORCH_LIBS} ${OPENCV_LIBS})
+  FOREACH(plib ${PT_LIBS} ${HPCX_LIBS} ${LIBTORCH_LIBS} ${OPENCV_LIBS})
     set(PT_LIB_PATHS ${PT_LIB_PATHS} "${CMAKE_CURRENT_BINARY_DIR}/${plib}")
   ENDFOREACH(plib)
 
@@ -444,7 +463,7 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     )
   endif() # TRITON_PYTORCH_ENABLE_TORCHTRT
 
-  FOREACH(plib ${PT_LIBS} ${LIBTORCH_LIBS} ${OPENCV_LIBS})
+  FOREACH(plib ${PT_LIBS} ${HPCX_LIBS} ${LIBTORCH_LIBS} ${OPENCV_LIBS})
     install(
       CODE
         "EXECUTE_PROCESS(
@@ -479,7 +498,7 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
       endif()"
   )
 else()
-  FOREACH(plib ${PT_LIBS})
+  FOREACH(plib ${PT_LIBS} ${HPCX_LIBS})
     set(PT_LIB_PATHS ${PT_LIB_PATHS} "${TRITON_PYTORCH_LIB_PATHS}/${plib}")
   ENDFOREACH(plib)
 
@@ -489,7 +508,7 @@ else()
     DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/pytorch
   )
 
-  FOREACH(plib ${PT_LIBS})
+  FOREACH(plib ${PT_LIBS} ${HPCX_LIBS})
     install(
       CODE
         "EXECUTE_PROCESS(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,11 @@ set(PT_LIBS
     "libtorch_cuda_linalg.so"
     "libtorch_global_deps.so"
     "libnvfuser_codegen.so"
+    "libucc.so.1"
+    "libucm.so.0"
+    "libucp.so.0"
+    "libucs.so.0"
+    "libuct.so.0"
 )
 
 if (${TRITON_PYTORCH_ENABLE_TORCHVISION})
@@ -254,7 +259,7 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     COMMENT "Extracting pytorch and torchvision libraries and includes from ${TRITON_PYTORCH_DOCKER_IMAGE}"
     VERBATIM
   )
-  add_custom_target(ptlib_target DEPENDS ${PT_LIBS} ${LIBTORCH_LIBS} ${OPENCV_LIBS})
+add_custom_target(ptlib_target DEPENDS ${PT_LIBS} ${LIBTORCH_LIBS} ${OPENCV_LIBS})
   add_library(ptlib SHARED IMPORTED GLOBAL)
   add_dependencies(ptlib ptlib_target)
 
@@ -497,27 +502,6 @@ else()
     )
   ENDFOREACH(plib)
 endif() # TRITON_PYTORCH_DOCKER_BUILD
-
-
-# Libtorch.so has dependencies in the hpcx folder that must be in the rpath.
-install(
-  CODE
-    "execute_process(
-      COMMAND patchelf --add-rpath /opt/hpcx/ucx/lib/ libtorch.so
-      RESULT_VARIABLE PATCHELF_STATUS
-      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
-    if(PATCHELF_STATUS AND NOT PATCHELF_STATUS EQUAL 0)
-      message(FATAL_ERROR \"FAILED: to run patchelf\")
-    endif()
-
-    execute_process(
-      COMMAND /sbin/ldconfig
-      RESULT_VARIABLE LDCONFIG_STATUS
-      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
-    if(LDCONFIG_STATUS AND NOT LDCONFIG_STATUS EQUAL 0)
-      message(FATAL_ERROR \"FAILED: to run ldconfig\")
-    endif()"
-)
 
 install(
   EXPORT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,6 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     COMMENT "Extracting pytorch and torchvision libraries and includes from ${TRITON_PYTORCH_DOCKER_IMAGE}"
     VERBATIM
   )
-  message(STATUS "hpcx libs: ${HPCX_LIBS}")
   add_custom_target(ptlib_target DEPENDS ${PT_LIBS} ${HPCX_LIBS} ${LIBTORCH_LIBS} ${OPENCV_LIBS})
   add_library(ptlib SHARED IMPORTED GLOBAL)
   add_dependencies(ptlib ptlib_target)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,11 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     COMMAND docker cp -L pytorch_backend_ptlib:/usr/local/lib/libopencv_calib3d.so libopencv_calib3d.so
     COMMAND docker cp -L pytorch_backend_ptlib:/usr/local/lib/libopencv_features2d.so libopencv_features2d.so
     COMMAND docker cp -L pytorch_backend_ptlib:/usr/local/lib/libopencv_flann.so libopencv_flann.so
+    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucc/lib/libucc.so.1 libucc.so.1
+    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucm.so.0 libucm.so.0
+    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucp.so.0 libucp.so.0
+    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucs.so.0 libucs.so.0
+    COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libuct.so.0 libuct.so.0
     COMMAND docker cp pytorch_backend_ptlib:/usr/lib/${LIBS_ARCH}-linux-gnu/libpng16.so.16.37.0 libpng16.so
     COMMAND docker cp pytorch_backend_ptlib:/usr/lib/${LIBS_ARCH}-linux-gnu/libjpeg.so.8.2.2 libjpeg.so
     COMMAND /bin/sh -c "if [ -f libmkl_def.so.1 ]; then patchelf --add-needed libmkl_gnu_thread.so.1 libmkl_def.so.1; fi"
@@ -493,6 +498,26 @@ else()
   ENDFOREACH(plib)
 endif() # TRITON_PYTORCH_DOCKER_BUILD
 
+
+# Libtorch.so has dependencies in the hpcx folder that must be in the rpath.
+install(
+  CODE
+    "execute_process(
+      COMMAND patchelf --add-rpath /opt/hpcx/ucx/lib/ libtorch.so
+      RESULT_VARIABLE PATCHELF_STATUS
+      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
+    if(PATCHELF_STATUS AND NOT PATCHELF_STATUS EQUAL 0)
+      message(FATAL_ERROR \"FAILED: to run patchelf\")
+    endif()
+
+    execute_process(
+      COMMAND /sbin/ldconfig
+      RESULT_VARIABLE LDCONFIG_STATUS
+      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
+    if(LDCONFIG_STATUS AND NOT LDCONFIG_STATUS EQUAL 0)
+      message(FATAL_ERROR \"FAILED: to run ldconfig\")
+    endif()"
+)
 
 install(
   EXPORT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,19 @@ else()
   ENDFOREACH(plib)
 endif() # TRITON_PYTORCH_DOCKER_BUILD
 
+
+# Libtorch.so has dependencies in the hpcx folder that must be in the rpath.
+install(
+      CODE
+        "EXECUTE_PROCESS(
+          COMMAND patchelf --set-rpath $ORIGIN:/opt/hpcx/ucx/lib/ libtorch.so
+          RESULT_VARIABLE PATCHELF_STATUS
+          WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
+        if(PATCHELF_STATUS AND NOT PATCHELF_STATUS EQUAL 0)
+          message(FATAL_ERROR \"FAILED: to run patchelf\")
+        endif()"
+    )
+
 install(
   EXPORT
     triton-pytorch-backend-targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
       include/torch
       include/torchvision
     COMMAND ${CMAKE_COMMAND} -E make_directory "include/torchvision"
-    COMMAND docker pull ${TRITON_PYTORCH_DOCKER_IMAGE}
+    # COMMAND docker pull ${TRITON_PYTORCH_DOCKER_IMAGE}
     COMMAND docker rm pytorch_backend_ptlib || echo "error ignored..." || true
     COMMAND docker create --name pytorch_backend_ptlib ${TRITON_PYTORCH_DOCKER_IMAGE}
     COMMAND /bin/sh -c "for i in ${LIBTORCH_LIBS_STR} ; do echo copying $i && docker cp -L pytorch_backend_ptlib:/usr/local/lib/$i $i ; done"
@@ -493,26 +493,6 @@ else()
   ENDFOREACH(plib)
 endif() # TRITON_PYTORCH_DOCKER_BUILD
 
-
-# Libtorch.so has dependencies in the hpcx folder that must be in the rpath.
-install(
-  CODE
-    "execute_process(
-      COMMAND patchelf --add-rpath /opt/hpcx/ucx/lib/ libtorch.so
-      RESULT_VARIABLE PATCHELF_STATUS
-      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
-    if(PATCHELF_STATUS AND NOT PATCHELF_STATUS EQUAL 0)
-      message(FATAL_ERROR \"FAILED: to run patchelf\")
-    endif()
-
-    execute_process(
-      COMMAND /sbin/ldconfig
-      RESULT_VARIABLE LDCONFIG_STATUS
-      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
-    if(LDCONFIG_STATUS AND NOT LDCONFIG_STATUS EQUAL 0)
-      message(FATAL_ERROR \"FAILED: to run ldconfig\")
-    endif()"
-)
 
 install(
   EXPORT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,6 @@ if(NOT TRITON_ENABLE_GPU)
       ${HPCX_LIBS}
     COMMAND docker pull ${TRITON_PYTORCH_DOCKER_IMAGE}
     COMMAND docker rm pytorch_backend_ptlib || echo "error ignored..." || true
-    COMMAND echo "Running ${TRITON_PYTORCH_DOCKER_IMAGE} to extract HPCX libraries"
     COMMAND docker create --name pytorch_backend_ptlib ${TRITON_PYTORCH_DOCKER_IMAGE}
     COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucc/lib/libucc.so.1 libucc.so.1
     COMMAND docker cp -L pytorch_backend_ptlib:/opt/hpcx/ucx/lib/libucm.so.0 libucm.so.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
       include/torch
       include/torchvision
     COMMAND ${CMAKE_COMMAND} -E make_directory "include/torchvision"
-    # COMMAND docker pull ${TRITON_PYTORCH_DOCKER_IMAGE}
+    COMMAND docker pull ${TRITON_PYTORCH_DOCKER_IMAGE}
     COMMAND docker rm pytorch_backend_ptlib || echo "error ignored..." || true
     COMMAND docker create --name pytorch_backend_ptlib ${TRITON_PYTORCH_DOCKER_IMAGE}
     COMMAND /bin/sh -c "for i in ${LIBTORCH_LIBS_STR} ; do echo copying $i && docker cp -L pytorch_backend_ptlib:/usr/local/lib/$i $i ; done"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,15 +496,19 @@ endif() # TRITON_PYTORCH_DOCKER_BUILD
 
 # Libtorch.so has dependencies in the hpcx folder that must be in the rpath.
 install(
-      CODE
-        "EXECUTE_PROCESS(
-          COMMAND patchelf --set-rpath $ORIGIN:/opt/hpcx/ucx/lib/ libtorch.so && /sbin/ldconfig
-          RESULT_VARIABLE PATCHELF_STATUS
-          WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
-        if(PATCHELF_STATUS AND NOT PATCHELF_STATUS EQUAL 0)
-          message(FATAL_ERROR \"FAILED: to run patchelf\")
-        endif()"
-    )
+  CODE
+    "execute_process(
+      COMMAND patchelf --add-rpath /opt/hpcx/ucx/lib/ libtorch.so
+      RESULT_VARIABLE PATCHELF_STATUS
+      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
+    if(PATCHELF_STATUS AND NOT PATCHELF_STATUS EQUAL 0)
+      message(FATAL_ERROR \"FAILED: to run patchelf\")
+    endif()
+
+    execute_process(
+      COMMAND /sbin/ldconfig
+    )"
+)
 
 install(
   EXPORT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ if(NOT TRITON_ENABLE_GPU)
   add_custom_command(
     OUTPUT
       ${HPCX_LIBS}
-    # COMMAND docker pull ${TRITON_PYTORCH_DOCKER_IMAGE}
+    COMMAND docker pull ${TRITON_PYTORCH_DOCKER_IMAGE}
     COMMAND docker rm pytorch_backend_ptlib || echo "error ignored..." || true
     COMMAND echo "Running ${TRITON_PYTORCH_DOCKER_IMAGE} to extract HPCX libraries"
     COMMAND docker create --name pytorch_backend_ptlib ${TRITON_PYTORCH_DOCKER_IMAGE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,7 +507,11 @@ install(
 
     execute_process(
       COMMAND /sbin/ldconfig
-    )"
+      RESULT_VARIABLE LDCONFIG_STATUS
+      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
+    if(LDCONFIG_STATUS AND NOT LDCONFIG_STATUS EQUAL 0)
+      message(FATAL_ERROR \"FAILED: to run ldconfig\")
+    endif()"
 )
 
 install(


### PR DESCRIPTION
Copy HPCX paths from the PyTorch container for CPU-only builds, so that it has the expected version of HPCX dependencies for libtorch.so.

Server: https://github.com/triton-inference-server/server/pull/5922