### PR TITLE
fix the crashing when there are zero-size inputs

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -2143,7 +2143,7 @@ ModelInstanceState::SetInputTensors(
         (*input_tensors)[input_index_map_[input_name]] = input_tensor;
       } else {
         // torch:from_blob seems not working when the input size is 0
-        // create zero-lenght inputs directly
+        // create zero-length inputs directly
         torch::Tensor input_tensor =
             torch::zeros(batchn_shape, updated_options);
         (*input_tensors)[input_index_map_[input_name]] = input_tensor;


### PR DESCRIPTION
PR to fix the crashing when some of the PyTorch inputs have zero size. One example here:

https://github.com/triton-inference-server/server/issues/5972

The error seems tbe be because of `Torch::from_blob` function for copying inputs not working when the tensor is zero-size. The fix is to add the special handle in this case, directly creating a zero-size tensor, instead of calling the PyTorch function.

Tested and it seems to have fixed the crashing.