### PR TITLE
Disable cudnn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,26 @@ key: "INFERENCE_MODE"
 }
 ```
 
+* `DISABLE_CUDNN`: Boolean flag to disable the cuDNN library. By default, cuDNN is enabled.
+
+[cuDNN](https://developer.nvidia.com/cudnn) is a GPU-accelerated library of primitives for 
+deep neural networks. cuDNN provides highly tuned implementations for standard routines.
+
+Typically, models run with cuDNN enabled are faster. However there are some exceptions
+where using cuDNN can be slower, cause higher memory usage or result in errors. 
+
+
+The section of model config file specifying this parameter will look like:
+
+```
+parameters: {
+key: "DISABLE_CUDNN"
+    value: {
+    string_value: "true"
+    }
+}
+```
+
 * `ENABLE_WEIGHT_SHARING`: Boolean flag to enable model instances on the same device to
 share weights. This optimization should not be used with stateful models. If not specified,
 weight sharing is disabled.

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -98,6 +98,7 @@ class ModelState : public BackendModel {
     return enable_jit_executor_pair_;
   }
   bool EnabledInferenceMode() { return enable_inference_mode_; }
+  bool EnabledCudnn() { return enable_cudnn_; }
   bool EnabledCacheCleaning() { return enable_cache_cleaning_; }
 
   bool EnabledWeightSharing() { return enable_weight_sharing_; }
@@ -118,6 +119,9 @@ class ModelState : public BackendModel {
 
   // Flag to indicate whether inference mode is enabled. Defaults to false.
   bool enable_inference_mode_;
+
+  // Flag to indicate whether cudnn is enabled. Defaults to true.
+  bool enable_cudnn_;
 
   // Flag to indicate whether cache cleaning after each run is enabled.
   // Defaults to false.
@@ -221,8 +225,9 @@ ModelState::Create(TRITONBACKEND_Model* triton_model, ModelState** state)
 
 ModelState::ModelState(TRITONBACKEND_Model* triton_model)
     : BackendModel(triton_model), enable_optimized_execution_(true),
-      enable_inference_mode_(true), enable_cache_cleaning_(false),
-      enable_weight_sharing_(false), enable_tensor_fuser_pair_({false, true}),
+      enable_inference_mode_(true), enable_cudnn_(true),
+      enable_cache_cleaning_(false), enable_weight_sharing_(false), 
+      enable_tensor_fuser_pair_({false, true}),
       enable_jit_profiling_pair_({false, true}),
       enable_jit_executor_pair_({false, true})
 {
@@ -384,6 +389,25 @@ ModelState::ParseParameters()
         TRITONSERVER_LOG_INFO,
         (std::string("Inference Mode is ") +
          (enable_inference_mode_ ? "enabled" : "disabled") +
+         " for model instance '" + Name() + "'")
+            .c_str());
+
+    // If 'INFERENCE_MODE' is not present in 'parameters' then no update is made
+    // to 'enable_inference_mode_'.
+    bool disable_cudnn = false;
+    err = ParseParameter(params, "DISABLE_CUDNN", &disable_cudnn);
+    if (err != nullptr) {
+      if (TRITONSERVER_ErrorCode(err) != TRITONSERVER_ERROR_NOT_FOUND) {
+        return err;
+      } else {
+        TRITONSERVER_ErrorDelete(err);
+      }
+    }
+    enable_cudnn_ = !disable_cudnn;
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
+        (std::string("cuDNN is ") +
+         (enable_cudnn_ ? "enabled" : "disabled") +
          " for model instance '" + Name() + "'")
             .c_str());
 
@@ -1507,6 +1531,9 @@ ModelInstanceState::Execute(
 
     // enable/disable inference mode - supersedes NoGradGuard
     torch::InferenceMode infer_guard(model_state_->EnabledInferenceMode());
+
+    // enable/disable cudnn
+    at::globalContext().setUserEnabledCuDNN(model_state_->EnabledCudnn());
 
     // JIT. No change is made unless parameter is explicitly set.
     if (std::get<0>(model_state_->EnabledJitProfiling())) {

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -392,8 +392,8 @@ ModelState::ParseParameters()
          " for model instance '" + Name() + "'")
             .c_str());
 
-    // If 'INFERENCE_MODE' is not present in 'parameters' then no update is made
-    // to 'enable_inference_mode_'.
+    // If 'DISABLE_CUDNN' is not present in 'parameters' then no update is made
+    // to 'enable_cudnn_'.
     bool disable_cudnn = false;
     err = ParseParameter(params, "DISABLE_CUDNN", &disable_cudnn);
     if (err != nullptr) {

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -226,7 +226,7 @@ ModelState::Create(TRITONBACKEND_Model* triton_model, ModelState** state)
 ModelState::ModelState(TRITONBACKEND_Model* triton_model)
     : BackendModel(triton_model), enable_optimized_execution_(true),
       enable_inference_mode_(true), enable_cudnn_(true),
-      enable_cache_cleaning_(false), enable_weight_sharing_(false), 
+      enable_cache_cleaning_(false), enable_weight_sharing_(false),
       enable_tensor_fuser_pair_({false, true}),
       enable_jit_profiling_pair_({false, true}),
       enable_jit_executor_pair_({false, true})
@@ -406,8 +406,7 @@ ModelState::ParseParameters()
     enable_cudnn_ = !disable_cudnn;
     LOG_MESSAGE(
         TRITONSERVER_LOG_INFO,
-        (std::string("cuDNN is ") +
-         (enable_cudnn_ ? "enabled" : "disabled") +
+        (std::string("cuDNN is ") + (enable_cudnn_ ? "enabled" : "disabled") +
          " for model instance '" + Name() + "'")
             .c_str());
 


### PR DESCRIPTION
We've occasionally had issues when multiple models that use cuDNN, (we sometimes see `CUDNN_INTERNAL_ERROR` and sometimes GPU memory will spike when running a kernel from cuDNN) so have found it beneficial to disable it in our own fork of the repo. It would be helpful to have an option to do this upstreamed.

If it would be helpful I could try and find a repro of the `CUDNN_INTERNAL_ERROR` issue but that may take a bit more time.