### PR TITLE
add thread control for pytorch backend

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -56,6 +56,12 @@
 #include <cuda_runtime_api.h>
 #endif  // TRITON_ENABLE_GPU
 
+// for thread control
+// https://pytorch.org/docs/stable/notes/cpu_threading_torchscript_inference.html#runtime-api
+// https://github.com/pytorch/pytorch/blob/v2.2.1-rc3/aten/src/ATen/Parallel.h#L133
+#include <ATen/Parallel.h>
+
+
 //
 // PyTorch C++ (LibTorch) Backend that implements the TRITONBACKEND API.
 //
@@ -464,6 +470,54 @@ ModelState::ParseParameters()
            (enable_jit_executor ? "enabled" : "disabled") +
            " for model instance '" + Name() + "'")
               .c_str());
+    }
+
+    // If "INTRA_OP_THREAD_COUNT" is not present in 'parameters' then no update
+    // is made to 'intra_op_thread_count', which by default will take all
+    // threads
+    int intra_op_thread_count = -1;
+    err = ParseParameterInt(
+        params, "INTRA_OP_THREAD_COUNT", &intra_op_thread_count);
+    if (err != nullptr) {
+      if (TRITONSERVER_ErrorCode(err) != TRITONSERVER_ERROR_NOT_FOUND) {
+        return err;
+      } else {
+        TRITONSERVER_ErrorDelete(err);
+      }
+    } else {
+      if (intra_op_thread_count > 0) {
+        at::set_num_threads(intra_op_thread_count);
+        LOG_MESSAGE(
+            TRITONSERVER_LOG_INFO,
+            (std::string("Intra op thread count is set to ") +
+             std::to_string(intra_op_thread_count) + " for model instance '" +
+             Name() + "'")
+                .c_str());
+      }
+    }
+
+    // If "INTER_OP_THREAD_COUNT" is not present in 'parameters' then no update
+    // is made to 'inter_op_thread_count', which by default will take all
+    // threads
+    int inter_op_thread_count = -1;
+    err = ParseParameterInt(
+        params, "INTER_OP_THREAD_COUNT", &inter_op_thread_count);
+    if (err != nullptr) {
+      if (TRITONSERVER_ErrorCode(err) != TRITONSERVER_ERROR_NOT_FOUND) {
+        return err;
+      } else {
+        TRITONSERVER_ErrorDelete(err);
+      }
+    } else {
+      if (inter_op_thread_count > 0) {
+        at::set_num_interop_threads(inter_op_thread_count);
+        LOG_MESSAGE(
+            TRITONSERVER_LOG_INFO,
+            (std::string("Inter op thread count is set to ") +
+             std::to_string(inter_op_thread_count) + " for model instance '" +
+             Name() + "'")
+                .c_str());
+      }
     }
   }
 

--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -472,11 +472,11 @@ ModelState::ParseParameters()
               .c_str());
     }
 
-    // If "INTRA_OP_THREAD_COUNT" is not present in 'parameters' then no update
+    // If 'INTRA_OP_THREAD_COUNT' is not present in 'parameters' then no update
     // is made to 'intra_op_thread_count', which by default will take all
     // threads
     int intra_op_thread_count = -1;
-    err = ParseParameterInt(
+    err = ParseParameter(
         params, "INTRA_OP_THREAD_COUNT", &intra_op_thread_count);
     if (err != nullptr) {
       if (TRITONSERVER_ErrorCode(err) != TRITONSERVER_ERROR_NOT_FOUND) {
@@ -496,11 +496,11 @@ ModelState::ParseParameters()
       }
     }
 
-    // If "INTER_OP_THREAD_COUNT" is not present in 'parameters' then no update
+    // If 'INTER_OP_THREAD_COUNT' is not present in 'parameters' then no update
     // is made to 'inter_op_thread_count', which by default will take all
     // threads
     int inter_op_thread_count = -1;
-    err = ParseParameterInt(
+    err = ParseParameter(
         params, "INTER_OP_THREAD_COUNT", &inter_op_thread_count);
     if (err != nullptr) {
       if (TRITONSERVER_ErrorCode(err) != TRITONSERVER_ERROR_NOT_FOUND) {

--- a/src/libtorch_utils.cc
+++ b/src/libtorch_utils.cc
@@ -149,6 +149,19 @@ ParseParameter(
   return nullptr;
 }
 
+TRITONSERVER_Error*
+ParseParameterInt(
+    triton::common::TritonJson::Value& params, const std::string& mkey,
+    int* value)
+{
+  std::string value_str;
+  RETURN_IF_ERROR(GetParameterValue(params, mkey, &value_str));
+  RETURN_IF_ERROR(ParseIntValue(value_str, value));
+
+  return nullptr;
+}
+
+
 #ifdef TRITON_ENABLE_GPU
 TRITONSERVER_Error*
 ConvertCUDAStatusToTritonError(

--- a/src/libtorch_utils.cc
+++ b/src/libtorch_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-21 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-24 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -150,7 +150,7 @@ ParseParameter(
 }
 
 TRITONSERVER_Error*
-ParseParameterInt(
+ParseParameter(
     triton::common::TritonJson::Value& params, const std::string& mkey,
     int* value)
 {

--- a/src/libtorch_utils.h
+++ b/src/libtorch_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -65,7 +65,7 @@ TRITONSERVER_Error* ParseParameter(
 // If the key 'mkey' is present in 'params' then update 'value' with the
 // value associated with that key. If 'mkey' is not present in 'params' then
 // 'value' is set to 'default_value'.
-TRITONSERVER_Error* ParseParameterInt(
+TRITONSERVER_Error* ParseParameter(
     triton::common::TritonJson::Value& params, const std::string& mkey,
     int* value);
 

--- a/src/libtorch_utils.h
+++ b/src/libtorch_utils.h
@@ -62,4 +62,11 @@ TRITONSERVER_Error* ParseParameter(
     triton::common::TritonJson::Value& params, const std::string& mkey,
     bool* value);
 
+// If the key 'mkey' is present in 'params' then update 'value' with the
+// value associated with that key. If 'mkey' is not present in 'params' then
+// 'value' is set to 'default_value'.
+TRITONSERVER_Error* ParseParameterInt(
+    triton::common::TritonJson::Value& params, const std::string& mkey,
+    int* value);
+
 }}}  // namespace triton::backend::pytorch


### PR DESCRIPTION
As noted in the issue here: https://github.com/triton-inference-server/server/issues/6896 we have found out the number of threads can affect the pytorch inference performance a lot. In some cases we have seen PyTorch inference runs (super) slow on multi-core CPU machines, and just setting number of instance is not enough to handle the problem. We have tested using `at::set_num_threads(1)` and confirmed this fixes the slow inference issue.

This PR allows to configure `intra_op_thread_count` and `inter_op_thread_count` for pytorch models, similar to other backends such as TF and ONNX, with syntax such as

```
parameters { key: "INTRA_OP_THREAD_COUNT" value: { string_value: "1" } }
parameters { key: "INTER_OP_THREAD_COUNT" value: { string_value: "1" } }
```