### PR TITLE
Add NVPL libraries to pytorch installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,16 @@ if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
   set(LIBS_ARCH "aarch64")
   set(LIBTORCH_LIBS
       "libopenblas.so.0"
+      "libnvpl_blas_core.so.0"
+      "libnvpl_blas_ilp64_gomp.so.0"
+      "libnvpl_blas_ilp64_seq.so.0"
+      "libnvpl_blas_lp64_gomp.so.0"
+      "libnvpl_blas_lp64_seq.so.0"
+      "libnvpl_lapack_core.so.0"
+      "libnvpl_lapack_ilp64_gomp.so.0"
+      "libnvpl_lapack_ilp64_seq.so.0"
+      "libnvpl_lapack_lp64_gomp.so.0"
+      "libnvpl_lapack_lp64_seq.so.0"
   )
 else()
   set(LIBS_ARCH "x86_64")


### PR DESCRIPTION
Fixes loading of TorchScript models on 24.05 containers