### PR TITLE
Build Using RHEL-Compatible Torchvision Lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,7 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     COMMAND docker cp -L pytorch_backend_ptlib:/usr/local/${LIB_DIR}/libopencv_features2d.so libopencv_features2d.so
     COMMAND docker cp -L pytorch_backend_ptlib:/usr/local/${LIB_DIR}/libopencv_flann.so libopencv_flann.so
     COMMAND /bin/sh -c "docker cp pytorch_backend_ptlib:$<IF:$<BOOL:${RHEL_BUILD}>,/usr/lib64/libpng16.so.16.34.0,/usr/lib/${LIBS_ARCH}-linux-gnu/libpng16.so.16.37.0> libpng16.so"
-    COMMAND /bin/sh -c "docker cp pytorch_backend_ptlib:$<IF:$<BOOL:${RHEL_BUILD}>,/usr/lib64/libjpeg.so.62.2.0,/usr/lib/${LIBS_ARCH}-linux-gnu/libjpeg.so.8.2.2> libjpeg.so"
+    COMMAND /bin/sh -c "docker cp pytorch_backend_ptlib:$<IF:$<BOOL:${RHEL_BUILD}>,/usr/lib64/libjpeg.so.62.2.0,/usr/local/lib/python3.10/dist-packages/torchvision/libjpeg.so.62> libjpeg.so.62"
     COMMAND /bin/sh -c "if [ -f libmkl_def.so.1 ]; then patchelf --add-needed libmkl_gnu_thread.so.1 libmkl_def.so.1; fi"
     COMMAND /bin/sh -c "if [ -f libmkl_def.so.1 ]; then patchelf --add-needed libmkl_core.so.1 libmkl_def.so.1; fi"
     COMMAND /bin/sh -c "if [ -f libmkl_avx2.so.1 ]; then patchelf --add-needed libmkl_gnu_thread.so.1 libmkl_avx2.so.1; fi"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,7 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     COMMAND docker cp -L pytorch_backend_ptlib:/usr/local/${LIB_DIR}/libopencv_features2d.so libopencv_features2d.so
     COMMAND docker cp -L pytorch_backend_ptlib:/usr/local/${LIB_DIR}/libopencv_flann.so libopencv_flann.so
     COMMAND /bin/sh -c "docker cp pytorch_backend_ptlib:$<IF:$<BOOL:${RHEL_BUILD}>,/usr/lib64/libpng16.so.16.34.0,/usr/lib/${LIBS_ARCH}-linux-gnu/libpng16.so.16.37.0> libpng16.so"
-    COMMAND /bin/sh -c "docker cp pytorch_backend_ptlib:$<IF:$<BOOL:${RHEL_BUILD}>,/usr/lib64/libjpeg.so.62.2.0,/usr/local/lib/python3.10/dist-packages/torchvision/libjpeg.so.62> libjpeg.so.62"
+    COMMAND /bin/sh -c "docker cp -L pytorch_backend_ptlib:$<IF:$<BOOL:${RHEL_BUILD}>,/usr/lib64/libjpeg.so.62,/usr/local/lib/python3.10/dist-packages/torchvision/libjpeg.so.62> libjpeg.so"
     COMMAND /bin/sh -c "if [ -f libmkl_def.so.1 ]; then patchelf --add-needed libmkl_gnu_thread.so.1 libmkl_def.so.1; fi"
     COMMAND /bin/sh -c "if [ -f libmkl_def.so.1 ]; then patchelf --add-needed libmkl_core.so.1 libmkl_def.so.1; fi"
     COMMAND /bin/sh -c "if [ -f libmkl_avx2.so.1 ]; then patchelf --add-needed libmkl_gnu_thread.so.1 libmkl_avx2.so.1; fi"
@@ -492,7 +492,7 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
         COMMAND ln -sf libopencv_features2d.so libopencv_features2d.so.${OPENCV_VERSION}
         COMMAND ln -sf libopencv_flann.so libopencv_flann.so.${OPENCV_VERSION}
         COMMAND ln -sf libpng16.so libpng16.so.16
-        COMMAND ln -sf libjpeg.so libjpeg.so.8
+        COMMAND ln -sf libjpeg.so libjpeg.so.62
         COMMAND ln -sf libcusparseLt.so libcusparseLt.so.0
         RESULT_VARIABLE LINK_STATUS
         WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)


### PR DESCRIPTION
**Goal:** Extract and build with the newly RHEL-compatible version of `libtorchvision.so`. The library can still be extracted from the same location, however, as part of this process, the lib has not been locked to depend on `libjpeg.so.62`.