### PR TITLE
Downgrade patchelf version from 0.18.0 to 0.17.2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ main Triton [issues page](https://github.com/triton-inference-server/server/issu
 Use a recent cmake to build. First install the required dependencies.
 
 ```
-$ apt-get install patchelf rapidjson-dev python3-dev
+$ apt-get install rapidjson-dev python3-dev python3-pip
+$ pip3 install patchelf==0.17.2
 ```
 
 An appropriate PyTorch container from [NGC](https://ngc.nvidia.com) must be used.


### PR DESCRIPTION
Downgrade patchelf version from 0.18.0 to 0.17.2 due to patchelf regression

    Patchelf shipped a regression in 0.18.0 and has since yanked the pypi release pointing to
    0.17.2 as the most recent version. However, 0.18.0 is still the version shipped in both the apt and yum
    repositories, thus we must use pip to install the version we want.
    See https://github.com/mayeut/patchelf-pypi/issues/87