### PR TITLE
Run in default mode when inference mode is disabled

### DIFF
--- a/src/libtorch.cc
+++ b/src/libtorch.cc
@@ -1606,8 +1606,6 @@ ModelInstanceState::Execute(
           std::get<1>(model_state_->EnabledTensorExprFuser()));
     }
 
-    torch::NoGradGuard no_grad;
-
     // If input is a dictionary, prepare dictionary from 'input_tensors'.
     if (is_dict_input_) {
       torch::Dict<std::string, torch::Tensor> input_dict;


### PR DESCRIPTION
When INFERENCE_MODE is set to false, the model still runs in no_grad mode. Is that intentional? This prevents the serving of models that requires gradients at inference time, such as differential rendering for example. Can we instead use the default mode when INFERENCE_MODE=false (as is implemented in this pull-request) or would it be preferable to add additional parameters to enable the default mode?

  Thanx!