### PR TITLE
Added Power CPU support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,16 +151,26 @@ endif() # TRITON_ENABLE_NVTX
 #
 configure_file(src/libtriton_pytorch.ldscript libtriton_pytorch.ldscript COPYONLY)
 
-set(PT_LIBS
-    "libc10.so"
-    "libc10_cuda.so"
-    "libtorch.so"
-    "libtorch_cpu.so"
-    "libtorch_cuda.so"
-    "libtorch_cuda_linalg.so"
-    "libtorch_global_deps.so"
-    "libjpeg.so.62"
-)
+if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
+  set(PT_LIBS
+      "libc10.so"
+      "libc10_cuda.so"
+      "libtorch.so"
+      "libtorch_cpu.so"
+      "libtorch_cuda.so"
+      "libtorch_cuda_linalg.so"
+      "libtorch_global_deps.so"
+      "libjpeg.so.62"
+ )
+ else()
+  set(PT_LIBS
+      "libc10.so"
+      "libtorch.so"
+      "libtorch_cpu.so"
+      "libtorch_global_deps.so"
+      "libjpeg.so.62"
+    )
+endif()
 
 if (${TRITON_PYTORCH_ENABLE_TORCHVISION})
   set(PT_LIBS


### PR DESCRIPTION
Hi Team, 
We are working on adding Power(ppc64le) support to triton-inference-server with pytorch_backend.
We were able to build pytorch_backend for CPU using the instructions mentioned here: https://github.com/triton-inference-server/pytorch_backend?tab=readme-ov-file#build-the-pytorch-backend-with-custom-pytorch.

Please let us know your thoughts about these changes. Thank you.