### PR TITLE
Fix an inssue that cuda stream not sync correctly in error case

### DIFF
--- a/src/pt/model_instance_state.cc
+++ b/src/pt/model_instance_state.cc
@@ -800,6 +800,12 @@ ModelInstanceState::ProcessRequests(
     }
   }
 
+#ifdef TRITON_ENABLE_GPU
+  if (Kind() == TRITONSERVER_INSTANCEGROUPKIND_GPU && invalid_index) {
+    cudaStreamSynchronize(GetCudaStreamByInstanceKind());
+  }
+#endif
+
   uint64_t exec_end_ns = 0;
   SET_TIMESTAMP(exec_end_ns);
 


### PR DESCRIPTION
Hi there, we ran into an issue that Triton server with pytorch_backend has a chance to be in a stuck state and fail to process any following request after processing an invalid payload.

After some investigation, we found that if `ModelInstanceState::Execute` experiences some issue and fails to generate output_tensors correctly, the following logic in `ModelInstanceState::ProcessRequests` will set `invalid_index=true` and skip the execution of `ModelInstanceState::ReadOutputTensors`, `ReadOutputTensors` is the place where the cuda stream sync should happen before calculating the inference duration as stated in the comment here: https://github.com/triton-inference-server/pytorch_backend/blob/main/src/model_instance_state.cc#L807

Skipping the cuda stream sync and call `GetCudaEventElapsedTime` has a chance to leave the cuda stream in a bad state and failed the following request.

An easy fix is to manually call the cuda stream sync even if the `ReadOutputTensors` method is not executed correctly.