### PR TITLE
Fix ValidateInputs crash for AOTI (pt2) models

### DIFF
--- a/src/pt2/model_instance_state.cc
+++ b/src/pt2/model_instance_state.cc
@@ -1851,8 +1851,12 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_count)
   //
   //   [1]                → tree_def for the outer (args, kwargs) tuple
   //   ["children_spec"]  → array of two children: [args_tuple, kwargs_dict]
-  //   [0]                → the args_tuple node (kwargs dict is always empty)
+  //   [0]                → the args_tuple node
   //   ["children_spec"]  → one entry per positional tensor argument
+  //
+  // We also navigate to [1] (the kwargs_dict node) and assert its
+  // children_spec is empty — models exported with tensor kwargs are rejected
+  // because Triton has no mechanism to supply named keyword arguments.
   //
   // IndexAsObject / MemberAsArray return nullptr on success, so chaining them
   // with && short-circuits at the first failure.
@@ -1870,16 +1874,29 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_count)
     TritonJsonValue outer_children;  // outer_tree["children_spec"]  — [args_tuple, kwargs_dict]
     TritonJsonValue args_tree;       // outer_children[0]            — the args tuple node
     TritonJsonValue args_children;   // args_tree["children_spec"]   — one entry per input tensor
+    TritonJsonValue kwargs_tree;     // outer_children[1]            — the kwargs dict node
+    TritonJsonValue kwargs_children; // kwargs_tree["children_spec"] — one entry per kwarg tensor
     bool nav_ok =
         (in_spec_doc.IndexAsObject(1, &outer_tree) == nullptr) &&
         (outer_tree.MemberAsArray("children_spec", &outer_children) == nullptr) &&
         (outer_children.IndexAsObject(0, &args_tree) == nullptr) &&
-        (args_tree.MemberAsArray("children_spec", &args_children) == nullptr);
+        (args_tree.MemberAsArray("children_spec", &args_children) == nullptr) &&
+        (outer_children.IndexAsObject(1, &kwargs_tree) == nullptr) &&
+        (kwargs_tree.MemberAsArray("children_spec", &kwargs_children) == nullptr);
     if (!nav_ok) {
       THROW_TRITON_EXCEPTION(
           TRITONSERVER_ERROR_INTERNAL,
           "Unexpected in_spec pytree structure for model \"" << Name() << "\": "
               << call_spec[0].substr(0, 200));
+    }
+    if (kwargs_children.ArraySize() > 0) {
+      THROW_TRITON_EXCEPTION(
+          TRITONSERVER_ERROR_INVALID_ARG,
+          "Model \"" << Name() << "\" was exported with "
+              << kwargs_children.ArraySize()
+              << " keyword-argument tensor input(s), which are not supported. "
+              << "Re-export using only positional arguments: "
+              << "torch.export.export(model, args=(x1, x2, ...), kwargs={})");
     }
     model_input_count = static_cast<size_t>(args_children.ArraySize());
   }

--- a/src/pt2/model_instance_state.cc
+++ b/src/pt2/model_instance_state.cc
@@ -1824,20 +1824,72 @@ void
 ModelInstanceState::ValidateInputs(const size_t expected_input_count)
 {
   DEBUG_TRACE_FUNCTION_CALL();
-  std::vector<std::string> allowed_inputs{model_->GetModelCallSpec()};
-
-  if (allowed_inputs.size() != expected_input_count) {
-    DEBUG_TRACE_ERROR(
-        "Failed to load model \""
-        << Name() << "\" configuration expects " << expected_input_count
-        << " inputs, but model expects " << allowed_inputs.size()
-        << " inputs.");
+  // get_call_spec() returns [in_spec, out_spec] — always exactly 2 strings.
+  // in_spec is a pytree spec "[<header_int>, <tree_def_object>]" produced by
+  // treespec_dumps().  The outer tuple encodes (args, kwargs), so in_spec is:
+  //   [1, {"type": "builtins.tuple", ..., "children_spec": [
+  //       {"type": "builtins.tuple", ..., "children_spec": [<N leaf nodes>]},
+  //       {"type": "builtins.dict",  ..., "children_spec": []}
+  //   ]}]
+  // json[0] is always 1 — it counts the outer (args, kwargs) wrapper as one
+  // node, NOT the number of inputs.  True count: in_spec[1]["children_spec"][0]
+  // ["children_spec"].size().
+  std::vector<std::string> call_spec{model_->GetModelCallSpec()};
+  if (call_spec.size() != 2 || call_spec[0].empty() || call_spec[0][0] != '[') {
     THROW_TRITON_EXCEPTION(
         TRITONSERVER_ERROR_INTERNAL,
-        "Failed to load model \""
-            << Name() << "\" configuration expects " << expected_input_count
-            << " inputs, but model expects " << allowed_inputs.size()
-            << " inputs.");
+        "Unexpected get_call_spec() format for model \"" << Name() << "\"");
+  }
+
+  // Parse in_spec with TritonJson to count the positional tensor inputs.
+  //
+  // TritonJson::Value::Parse accepts a top-level JSON array (rapidjson handles
+  // both objects and arrays).  in_spec is [<int>, <object>], so element [0] is
+  // an integer (skipped) and element [1] is the tree_def object.
+  //
+  // We need:  in_spec[1]["children_spec"][0]["children_spec"].size()
+  //
+  //   [1]                → tree_def for the outer (args, kwargs) tuple
+  //   ["children_spec"]  → array of two children: [args_tuple, kwargs_dict]
+  //   [0]                → the args_tuple node (kwargs dict is always empty)
+  //   ["children_spec"]  → one entry per positional tensor argument
+  //
+  // IndexAsObject / MemberAsArray return nullptr on success, so chaining them
+  // with && short-circuits at the first failure.
+  size_t model_input_count = 0;
+  {
+    TritonJsonValue in_spec_doc;
+    TRITONSERVER_Error* parse_err =
+        in_spec_doc.Parse(call_spec[0].c_str(), call_spec[0].size());
+    if (parse_err != nullptr) {
+      THROW_TRITON_EXCEPTION(
+          parse_err,
+          "Failed to parse in_spec JSON for model \"" << Name() << "\"");
+    }
+    TritonJsonValue outer_tree;      // in_spec_doc[1]               — outer (args,kwargs) tree_def
+    TritonJsonValue outer_children;  // outer_tree["children_spec"]  — [args_tuple, kwargs_dict]
+    TritonJsonValue args_tree;       // outer_children[0]            — the args tuple node
+    TritonJsonValue args_children;   // args_tree["children_spec"]   — one entry per input tensor
+    bool nav_ok =
+        (in_spec_doc.IndexAsObject(1, &outer_tree) == nullptr) &&
+        (outer_tree.MemberAsArray("children_spec", &outer_children) == nullptr) &&
+        (outer_children.IndexAsObject(0, &args_tree) == nullptr) &&
+        (args_tree.MemberAsArray("children_spec", &args_children) == nullptr);
+    if (!nav_ok) {
+      THROW_TRITON_EXCEPTION(
+          TRITONSERVER_ERROR_INTERNAL,
+          "Unexpected in_spec pytree structure for model \"" << Name() << "\": "
+              << call_spec[0].substr(0, 200));
+    }
+    model_input_count = static_cast<size_t>(args_children.ArraySize());
+  }
+
+  if (model_input_count != expected_input_count) {
+    THROW_TRITON_EXCEPTION(
+        TRITONSERVER_ERROR_INTERNAL,
+        "Failed to load model \"" << Name() << "\" configuration expects "
+            << expected_input_count << " inputs, but model expects "
+            << model_input_count << " inputs.");
   }
 
   /* CANNOT VALIDATE INPUTS BY DTYPE DUE TO LACK OF INFORMATION FROM MODEL */
@@ -1866,7 +1918,17 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_count)
             << " inputs.");
   }
 
-  auto naming_convention = GetNamingConvention(allowed_inputs);
+  // Pytree specs encode the tensor tree structure but carry no argument names,
+  // so positional ordering is the only option for AOTI models.
+  // STRICT_CONFIG_ORDERING maps each config input to its runner slot by the
+  // loop index i, i.e.  input_index_map_[io_name] = i  (see AddInputToMap).
+  auto naming_convention = TritonNamingConvention::STRICT_CONFIG_ORDERING;
+
+  // allowed_inputs is only consulted by the FORWARD_ARGUMENT branch inside
+  // AddInputToMap (name-based lookup).  Under STRICT_CONFIG_ORDERING that
+  // branch is never reached, so this vector is never read — it exists solely
+  // to satisfy the function signature.
+  std::vector<std::string> allowed_inputs{};
 
   for (size_t i = 0; i < ios.ArraySize(); i += 1) {
     TritonJsonValue io;


### PR DESCRIPTION
# Fix `ValidateInputs` crash for AOTI models

**Component:** `src/pt2/model_instance_state.cc` — `ModelInstanceState::ValidateInputs`  
**Severity:** Critical — all `torch_aoti` (`.pt2`) models fail to load  
**Affects:** `pytorch_backend` from the initial AOTI commit (`688df56`, 2026-03-04) onwards

---

## Symptom

Any `torch_aoti` model fails immediately at load time:

```
Failed to load model "my_model_0" configuration expects 1 inputs, but model expects 2 inputs.
```

This fires for every model regardless of actual input count. The model never becomes `READY`.

---

## Root Cause

`ValidateInputs` calls `GetModelCallSpec()` (which wraps `AOTIModelPackageLoader::get_call_spec()`) and uses the result's size as the input count. Since PyTorch first introduced `get_call_spec()` ([#110020](https://github.com/pytorch/pytorch/pull/110020), Oct 2023) it has **always returned exactly two strings**: the pytree specs for inputs and outputs.

```cpp
// Bug since commit 688df56 — allowed_inputs.size() is always 2
std::vector<std::string> allowed_inputs{model_->GetModelCallSpec()};
if (allowed_inputs.size() != expected_input_count) {   // always 2 != 1
    THROW_TRITON_EXCEPTION(..., "model expects " << allowed_inputs.size() << " inputs.");
}
```

### What `get_call_spec()` actually returns

Both strings are pytree specs from `treespec_dumps()` ([#106116](https://github.com/pytorch/pytorch/pull/106116)), serialised as `[<header_int>, <tree_def>]`. The `in_spec` encodes the `(args, kwargs)` call signature:

```
in_spec = [1, {"type": "builtins.tuple", ..., "children_spec": [
               {"type": "builtins.tuple", ..., "children_spec": [<N leaf nodes>]},  ← args
               {"type": "builtins.dict",  ..., "children_spec": []}                 ← kwargs
           ]}]
```

The header integer `json[0]` is **always `1`** — it counts the outer `(args, kwargs)` wrapper as a single node, not the number of tensor inputs. The true input count is the length of the inner args tuple's `children_spec`:

```
in_spec[1]["children_spec"][0]["children_spec"].size()   ← correct count
```

Verified across 1-, 3-, and 5-input models (ARM64, PyTorch 2.11, NGC 26.03):

| Model    | `len(get_call_spec())` | `json[0]` | `in_spec[1]["children_spec"][0]["children_spec"].size()` |
|----------|------------------------|-----------|----------------------------------------------------------|
| 1 input  | 2                      | 1         | **1** ✓                                                  |
| 3 inputs | 2                      | 1         | **3** ✓                                                  |
| 5 inputs | 2                      | 1         | **5** ✓                                                  |

---

## Fix

Parse `in_spec` with `TritonJson::Value` (already used throughout the file) and navigate the pytree JSON to count args leaves directly.

```diff
-  std::vector<std::string> allowed_inputs{model_->GetModelCallSpec()};
-  if (allowed_inputs.size() != expected_input_count) {
+  // get_call_spec() returns [in_spec, out_spec] — always exactly 2 strings.
+  // in_spec is a pytree spec "[<header_int>, <tree_def_object>]" produced by
+  // treespec_dumps().  The outer tuple encodes (args, kwargs), so in_spec is:
+  //   [1, {"type": "builtins.tuple", ..., "children_spec": [
+  //       {"type": "builtins.tuple", ..., "children_spec": [<N leaf nodes>]},
+  //       {"type": "builtins.dict",  ..., "children_spec": []}
+  //   ]}]
+  // json[0] is always 1 — it counts the outer (args, kwargs) wrapper as one
+  // node, NOT the number of inputs.  True count: in_spec[1]["children_spec"][0]
+  // ["children_spec"].size().
+  std::vector<std::string> call_spec{model_->GetModelCallSpec()};
+  if (call_spec.size() != 2 || call_spec[0].empty() || call_spec[0][0] != '[') {
+    THROW_TRITON_EXCEPTION(TRITONSERVER_ERROR_INTERNAL,
+        "Unexpected get_call_spec() format for model \"" << Name() << "\"");
+  }
+
+  // Parse in_spec with TritonJson to count the positional tensor inputs.
+  //
+  // TritonJson::Value::Parse accepts a top-level JSON array (rapidjson handles
+  // both objects and arrays).  in_spec is [<int>, <object>], so element [0] is
+  // an integer (skipped) and element [1] is the tree_def object.
+  //
+  // We need:  in_spec[1]["children_spec"][0]["children_spec"].size()
+  //
+  //   [1]                → tree_def for the outer (args, kwargs) tuple
+  //   ["children_spec"]  → array of two children: [args_tuple, kwargs_dict]
+  //   [0]                → the args_tuple node (kwargs dict is always empty)
+  //   ["children_spec"]  → one entry per positional tensor argument
+  //
+  // IndexAsObject / MemberAsArray return nullptr on success, so chaining them
+  // with && short-circuits at the first failure.
+  size_t model_input_count = 0;
+  {
+    TritonJsonValue in_spec_doc;
+    TRITONSERVER_Error* parse_err =
+        in_spec_doc.Parse(call_spec[0].c_str(), call_spec[0].size());
+    if (parse_err != nullptr) {
+      THROW_TRITON_EXCEPTION(parse_err,
+          "Failed to parse in_spec JSON for model \"" << Name() << "\"");
+    }
+    TritonJsonValue outer_tree;      // in_spec_doc[1]               — outer (args,kwargs) tree_def
+    TritonJsonValue outer_children;  // outer_tree["children_spec"]  — [args_tuple, kwargs_dict]
+    TritonJsonValue args_tree;       // outer_children[0]            — the args tuple node
+    TritonJsonValue args_children;   // args_tree["children_spec"]   — one entry per input tensor
+    bool nav_ok =
+        (in_spec_doc.IndexAsObject(1, &outer_tree) == nullptr) &&
+        (outer_tree.MemberAsArray("children_spec", &outer_children) == nullptr) &&
+        (outer_children.IndexAsObject(0, &args_tree) == nullptr) &&
+        (args_tree.MemberAsArray("children_spec", &args_children) == nullptr);
+    if (!nav_ok) {
+      THROW_TRITON_EXCEPTION(TRITONSERVER_ERROR_INTERNAL,
+          "Unexpected in_spec pytree structure for model \"" << Name() << "\": "
+          << call_spec[0].substr(0, 200));
+    }
+    model_input_count = static_cast<size_t>(args_children.ArraySize());
+  }
+
+  if (model_input_count != expected_input_count) {
     THROW_TRITON_EXCEPTION(TRITONSERVER_ERROR_INTERNAL,
         "Failed to load model \"" << Name() << "\" configuration expects "
-        << expected_input_count << " inputs, but model expects "
-        << allowed_inputs.size() << " inputs.");
+        << expected_input_count << " inputs, but model expects "
+        << model_input_count << " inputs.");
   }

   /* ... ios validation, dtype checks unchanged ... */

-  auto naming_convention = GetNamingConvention(allowed_inputs);
+  // Pytree specs encode the tensor tree structure but carry no argument names,
+  // so positional ordering is the only option for AOTI models.
+  // STRICT_CONFIG_ORDERING maps each config input to its runner slot by the
+  // loop index i, i.e.  input_index_map_[io_name] = i  (see AddInputToMap).
+  auto naming_convention = TritonNamingConvention::STRICT_CONFIG_ORDERING;
+
+  // allowed_inputs is only consulted by the FORWARD_ARGUMENT branch inside
+  // AddInputToMap (name-based lookup).  Under STRICT_CONFIG_ORDERING that
+  // branch is never reached, so this vector is never read — it exists solely
+  // to satisfy the function signature.
+  std::vector<std::string> allowed_inputs{};
```

---

## Validation

**Environment:** ARM64 (Apple Silicon / OrbStack), `nvcr.io/nvidia/tritonserver:26.03-py3`, PyTorch 2.11.0+cpu, CPU-only instance group.

**Stock backend** — fails for every model regardless of input count:

```
# 1-input model (config expects 1, get_call_spec() returns 2 strings)
Failed to load model "minimal_model_0_0" configuration expects 1 inputs, but model expects 2 inputs.

# 3-input model
Failed to load model "model_3in_0_0" configuration expects 3 inputs, but model expects 2 inputs.
```

**Patched backend** — all models load, outputs verified numerically (exit 0):

```
✓ Model 'minimal_model' is READY   output matches x * 2.0      ✓ Inference PASSED
✓ Model 'model_1in'     is READY   output matches x_1 * 2.0    ✓ Inference PASSED
✓ Model 'model_3in'     is READY   output matches x_1+x_2+x_3  ✓ Inference PASSED
✓ Model 'model_5in'     is READY   output matches x_1+…+x_5    ✓ Inference PASSED
```

**`get_call_spec()` values observed on ARM64 PyTorch 2.11, across all input counts:**

```
model_1in  len(specs)=2  json[0]=1  treespec_loads().num_leaves=1  ✓ PASS
model_3in  len(specs)=2  json[0]=1  treespec_loads().num_leaves=3  ✓ PASS
model_5in  len(specs)=2  json[0]=1  treespec_loads().num_leaves=5  ✓ PASS
```

---

## References

- [pytorch/pytorch#106116](https://github.com/pytorch/pytorch/pull/106116) — introduced `treespec_dumps` pytree serialisation.
- [pytorch/pytorch#110020](https://github.com/pytorch/pytorch/pull/110020) — introduced `get_call_spec()` returning `{in_spec, out_spec}`.
- [triton-inference-server/pytorch_backend `688df56`](https://github.com/triton-inference-server/pytorch_backend/commit/688df56) — introduced the incorrect `ValidateInputs` assumption.
