### PR TITLE
build: set OpenSSL3 paths on RHEL-like Linux (TRI-938)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ if(LINUX)
     if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
       set(LIBTORCH_LIBS_PATH "/opt/_internal/cpython-3.12.1/lib")
     endif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+    set(OPENSSL_ROOT_DIR "/usr/lib64/openssl3")
+    set(OPENSSL_INCLUDE_DIR "/usr/include/openssl3")
   endif(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
 endif(LINUX)
 


### PR DESCRIPTION
## Description
Updates CMake so OpenSSL 3 library paths are set on RHEL-like Linux for manylinux/repack builds. Cross-repo change; related PRs are listed below.

## Changes
- 1e5f14f build: set OpenSSL3 paths on RHEL-like Linux (TRI-938)

## Affected Files
- CMakeLists.txt

#### Related PRs (other repositories)
- triton-inference-server/server#8731
- triton-inference-server/core#488
- triton-inference-server/client#886
- triton-inference-server/third_party#73
- triton-inference-server/tensorrt_backend#119
- triton-inference-server/python_backend#434

#### Test plan
- Confirm CI for this repository completes successfully.
- CI Pipeline ID: (fill when available)

#### Related Issues
- Resolves Linear issue: TRI-938
