### PR TITLE
post: Update default branch post-26.05

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,8 +286,8 @@ else()
   )
 endif()
 set(TORCHVISION_LIBS
-    $<IF:$<BOOL:${RHEL_BUILD}>,libjpeg.so.62,libjpeg.so>
-    $<IF:$<BOOL:${RHEL_BUILD}>,libpng16.so.16,libpng16.so>
+    libjpeg.so.62
+    libpng16.so.16
 )
 
 message(TRACE "LIBS_ARCH: ${LIBS_ARCH}")
@@ -335,8 +335,8 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     COMMAND docker cp pytorch_backend_ptlib:${PY_INSTALL_PATH}/torch/include include/torch
     COMMAND docker cp pytorch_backend_ptlib:/opt/pytorch/pytorch/torch/csrc/jit/codegen include/torch/torch/csrc/jit/.
 
-    COMMAND /bin/sh -c "if [ ${RHEL_BUILD} = 'ON' ]; then docker cp -L pytorch_backend_ptlib:/usr/lib64/libjpeg.so.62 libjpeg.so.62; else docker cp -L pytorch_backend_ptlib:/usr/local/lib/libjpeg.so.62 libjpeg.so.62 && docker cp pytorch_backend_ptlib:/usr/lib/${LIBS_ARCH}-linux-gnu/libjpeg.so.8.2.2 libjpeg.so; fi;"
-    COMMAND /bin/sh -c "if [ ${RHEL_BUILD} = 'ON' ]; then docker cp -L pytorch_backend_ptlib:/usr/lib64/libpng16.so.16 libpng16.so.16; else docker cp -L pytorch_backend_ptlib:/usr/lib/${LIBS_ARCH}-linux-gnu/libpng16.so libpng16.so; fi;"
+    COMMAND /bin/sh -c "if [ ${RHEL_BUILD} = 'ON' ]; then docker cp -L pytorch_backend_ptlib:/usr/lib64/libjpeg.so.62 libjpeg.so.62; else docker cp -L pytorch_backend_ptlib:/usr/local/lib/libjpeg.so.62 libjpeg.so.62 ; fi;"
+    COMMAND /bin/sh -c "if [ ${RHEL_BUILD} = 'ON' ]; then docker cp -L pytorch_backend_ptlib:/usr/lib64/libpng16.so.16 libpng16.so.16; else docker cp -L pytorch_backend_ptlib:/usr/lib/${LIBS_ARCH}-linux-gnu/libpng16.so.16 libpng16.so.16; fi;"
     COMMAND /bin/sh -c "if [ -f libmkl_def.so.1 ]; then patchelf --add-needed libmkl_gnu_thread.so.1 libmkl_def.so.1; fi"
     COMMAND /bin/sh -c "if [ -f libmkl_def.so.1 ]; then patchelf --add-needed libmkl_core.so.1 libmkl_def.so.1; fi"
     COMMAND /bin/sh -c "if [ -f libmkl_avx2.so.1 ]; then patchelf --add-needed libmkl_gnu_thread.so.1 libmkl_avx2.so.1; fi"
@@ -562,17 +562,6 @@ if (${TRITON_PYTORCH_DOCKER_BUILD})
     )
   ENDFOREACH(plib)
 
-  install(
-    CODE
-      "EXECUTE_PROCESS(
-        COMMAND ln -sf libpng16.so libpng16.so.16
-        COMMAND ln -sf libjpeg.so libjpeg.so.8
-        RESULT_VARIABLE LINK_STATUS
-        WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/backends/pytorch)
-      if(LINK_STATUS AND NOT LINK_STATUS EQUAL 0)
-        message(FATAL_ERROR \"FAILED: to create links\")
-      endif()"
-  )
 else()
   FOREACH(plib ${PT_LIBS})
     set(PT_LIB_PATHS ${PT_LIB_PATHS} "${TRITON_PYTORCH_LIB_PATHS}/${plib}")


### PR DESCRIPTION
<sup>CI (internal): [#52829374](http://tritonserver.local/ci/pipelines/52829374)</sup>

#### What does the PR do?

Cherry-pick of `r26.05`#191 ("fix: streamline library distribution for 26.05 upstream container build") to `main`: removes an absent reference and changes library distribution out of the PyTorch image. Required so `main` can build against the `26.05` upstream container.

Changed files: `CMakeLists.txt`.

#### Checklist

- [x] I have made sure this PR is not a duplicate.
- [x] I have made sure the commit message is clear and follows [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] I have added unit tests for any new functionality.
- [x] I have made sure all tests are passing.
- [ ] For documentation changes: I have previewed the changes and they render correctly.

#### Commit Type:

- [ ] `feat` (A new feature)
- [x] `fix` (A bug fix)
- [ ] `docs` (Documentation-only changes)
- [ ] `style` (Changes that do not affect the meaning of the code — formatting, whitespace, etc.)
- [ ] `refactor` (A code change that neither fixes a bug nor adds a feature)
- [ ] `perf` (A code change that improves performance)
- [ ] `test` (Adding missing tests or correcting existing tests)
- [x] `build` (Changes that affect the build system or external dependencies)
- [ ] `ci` (Changes to CI configuration files and scripts)
- [ ] `chore` (Other changes that don't modify src or test files)

#### Related PRs:

- triton-inference-server/server#8804
- triton-inference-server/model_analyzer#1024
- triton-inference-server/tensorrtllm_backend#857

Original (r26.05): triton-inference-server/pytorch_backend#191

#### Where should the reviewer start?

`CMakeLists.txt`

#### Test plan:

Cherry-pick of an already-merged fix on `r26.05`; verified against the 26.05 upstream container build.

- CI Pipeline ID: 52829374

#### Caveats:

Cherry-pick from `r26.05`.

#### Background

Part of TRI-1063 post-26.04 release maintenance: forward-port the 26.05 library-distribution fix so `main` builds cleanly against the 26.05 upstream container.

#### Related Issues:

Resolves: TRI-1063
