### PR TITLE
NV embedding layer loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,7 @@ target_link_libraries(
     triton-core-backendapi # from repo-core
     triton-core-serverstub # from repo-core
     triton-backend-utils   # from repo-backend
+    ${CMAKE_DL_LIBS}       # dlopen/dlsym/dlclose for the MODEL_INIT_LIBRARY hook
     ${TRITON_PYTORCH_LDFLAGS}
     ${TRITON_PYTORCH_LIBS}
     $<$<BOOL:${TRITON_PYTORCH_OPTREE}>:optree>

--- a/README.md
+++ b/README.md
@@ -305,6 +305,56 @@ output: [
 > Support for batch sizes greater than 1 and for sequence batching for AOT Inductor compiled models has not be completed.
 > These Triton Server features are currently unavailable for PyTorch models compiled using AOT Inductor and packaged as a PT2 model archive.
 
+### Model Initialization Hook (`MODEL_INIT_LIBRARY`)
+
+Some models need to run one-time **native** initialization at load time — before
+the model package is loaded — that cannot be expressed inside `model.pt2`. A
+typical case is a model whose custom operators resolve large weights from a
+process-global registry at execute time, where those weights live outside the
+package (e.g. in sidecar files next to `model.pt2`) and must be read into memory
+and registered first.
+
+The PT2 path supports an optional, per-model hook for this. When a model's
+`config.pbtxt` sets the `MODEL_INIT_LIBRARY` parameter, the backend `dlopen()`s
+that shared library at model load and calls its initialization entry point. The
+backend does **not** link against the library and knows nothing about what it
+does; it only loads it, calls a fixed entry point, and releases it on unload.
+
+```
+parameters {
+  key: "MODEL_INIT_LIBRARY"
+  value: { string_value: "/abs/path/to/libmy_model_init.so" }
+}
+```
+
+The library must export the following C entry point, and may optionally export a
+matching finalizer:
+
+```c
+// Called once at model load, before the model package is loaded.
+//   model_dir    : the versioned model directory (the one containing model.pt2)
+//   device_index : the GPU ordinal for the instance, or -1 for CPU
+// Returns an opaque handle that is passed back to the finalizer on unload, or
+// NULL if there is nothing to keep.
+extern "C" void* triton_pytorch_model_init(const char* model_dir, int device_index);
+
+// Optional. Called once on model unload with the handle returned above.
+extern "C" void  triton_pytorch_model_fini(void* state);
+```
+
+If `MODEL_INIT_LIBRARY` is unset (the default), no library is loaded and this is
+a complete no-op. If it is set but the library cannot be `dlopen()`ed or does not
+export `triton_pytorch_model_init`, model load fails with an error.
+
+> [!WARNING]
+> `MODEL_INIT_LIBRARY` makes the backend load and execute native code from the
+> path given in the model configuration, in the server process and with its
+> privileges. Only point it at libraries you trust. This is the same trust level
+> already required for the model repository itself — a PT2 package contains
+> compiled code that runs when the model is loaded — so it does not widen the
+> trust boundary, but the model repository must remain a trusted,
+> operator-controlled source.
+
 ### PyTorch 2.0 Models
 
 PyTorch 2.0 features are available.

--- a/src/pt2/model_state.cc
+++ b/src/pt2/model_state.cc
@@ -353,9 +353,9 @@ ModelState::LoadModel(
 
   // Optional per-model native init hook (MODEL_INIT_LIBRARY parameter). Lets a
   // model run one-time native setup before its package is loaded -- e.g.
-  // loading external embedding weights into a process-global registry -- without
-  // the backend linking against or knowing anything about that library. No-op
-  // when the parameter is unset.
+  // loading external embedding weights into a process-global registry --
+  // without the backend linking against or knowing anything about that library.
+  // No-op when the parameter is unset.
   MaybeRunModelInitHook(repository_path, repository_version, device);
 
   std::pair<bool, int> device_pair{false, 0};
@@ -723,9 +723,9 @@ ModelState::ParseParameters()
 
     if (!model_init_library_.empty()) {
       TRITON_LOG_INFO(
-          "Model-init library is \""
-          << model_init_library_ << "\" for model instance \"" << Name()
-          << "\".");
+          "Model-init library is \"" << model_init_library_
+                                     << "\" for model instance \"" << Name()
+                                     << "\".");
     }
 
     DEBUG_TRACE_INFO(

--- a/src/pt2/model_state.cc
+++ b/src/pt2/model_state.cc
@@ -26,6 +26,8 @@
 
 #include "model_state.hh"
 
+#include <dlfcn.h>
+
 #include <mutex>
 
 #include "../libtorch.hh"
@@ -349,6 +351,13 @@ ModelState::LoadModel(
             << local_file_path << "\" is unreachable or inaccessible.");
   }
 
+  // Optional per-model native init hook (MODEL_INIT_LIBRARY parameter). Lets a
+  // model run one-time native setup before its package is loaded -- e.g.
+  // loading external embedding weights into a process-global registry -- without
+  // the backend linking against or knowing anything about that library. No-op
+  // when the parameter is unset.
+  MaybeRunModelInitHook(repository_path, repository_version, device);
+
   std::pair<bool, int> device_pair{false, 0};
   if (weight_sharing_enabled_) {
     device_pair = std::make_pair(!device.is_cpu(), device.index());
@@ -555,7 +564,7 @@ void
 ModelState::ParseParameters()
 {
   TritonJsonValue parameters;
-  if (!ModelConfig().Find("parameters", &parameters)) {
+  if (ModelConfig().Find("parameters", &parameters)) {
     bool disable_optimized_execution{false};
     if (auto err = ParseParameter(
             parameters, "DISABLE_OPTIMIZED_EXECUTION",
@@ -696,6 +705,29 @@ ModelState::ParseParameters()
       }
       TRITONSERVER_ErrorDelete(err);
     }
+    {
+      TritonJsonValue init_lib_param;
+      if (parameters.Find("MODEL_INIT_LIBRARY", &init_lib_param)) {
+        if (auto err = init_lib_param.MemberAsString(
+                "string_value", &model_init_library_)) {
+          DEBUG_TRACE_ERROR(
+              "{ model: \"" << Name() << "\", error: \""
+                            << TRITONSERVER_ErrorMessage(err) << "\" }");
+          THROW_TRITON_EXCEPTION(
+              TRITONSERVER_ErrorCode(err),
+              "Failed to parse 'MODEL_INIT_LIBRARY' parameter for model \""
+                  << Name() << "\": " << TRITONSERVER_ErrorMessage(err) << ".");
+        }
+      }
+    }
+
+    if (!model_init_library_.empty()) {
+      TRITON_LOG_INFO(
+          "Model-init library is \""
+          << model_init_library_ << "\" for model instance \"" << Name()
+          << "\".");
+    }
+
     DEBUG_TRACE_INFO(
         "{ disable_optimized_execution: "
         << (disable_optimized_execution ? "true" : "false")
@@ -717,6 +749,68 @@ ModelState::ParseParameters()
                                              << " for model instance "
                                              << "\"" << Name() << "\".");
     }
+  }
+}
+
+void
+ModelState::MaybeRunModelInitHook(
+    const std::string& repository_path, const std::string& repository_version,
+    const torch::Device& device)
+{
+  // No hook configured, or it already ran for this model.
+  if (model_init_library_.empty() || model_init_dl_handle_ != nullptr) {
+    return;
+  }
+
+  const std::string package_dir =
+      triton::backend::JoinPath({repository_path, repository_version});
+  // GPU ordinal; -1 for CPU. The hook decides how to interpret it.
+  const int device_index = device.index();
+
+  void* handle = dlopen(model_init_library_.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (handle == nullptr) {
+    const char* dl_err = dlerror();
+    THROW_TRITON_EXCEPTION(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "Failed to dlopen MODEL_INIT_LIBRARY \""
+            << model_init_library_ << "\" for model \"" << Name()
+            << "\": " << (dl_err != nullptr ? dl_err : "unknown error") << ".");
+  }
+
+  using ModelInitFn = void* (*)(const char*, int);
+  dlerror();  // Clear any stale error.
+  auto* init_fn =
+      reinterpret_cast<ModelInitFn>(dlsym(handle, "triton_pytorch_model_init"));
+  const char* sym_err = dlerror();
+  if (init_fn == nullptr || sym_err != nullptr) {
+    dlclose(handle);
+    THROW_TRITON_EXCEPTION(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "MODEL_INIT_LIBRARY \""
+            << model_init_library_
+            << "\" does not export 'triton_pytorch_model_init' for model \""
+            << Name() << "\": " << (sym_err != nullptr ? sym_err : "not found")
+            << ".");
+  }
+
+  model_init_state_ = init_fn(package_dir.c_str(), device_index);
+  model_init_dl_handle_ = handle;
+  TRITON_LOG_INFO(
+      "Ran model-init hook \"" << model_init_library_ << "\" for model \""
+                               << Name() << "\" (device_index=" << device_index
+                               << ").");
+}
+
+ModelState::~ModelState()
+{
+  if (model_init_dl_handle_ != nullptr) {
+    using ModelFiniFn = void (*)(void*);
+    auto* fini_fn = reinterpret_cast<ModelFiniFn>(
+        dlsym(model_init_dl_handle_, "triton_pytorch_model_fini"));
+    if (fini_fn != nullptr) {
+      fini_fn(model_init_state_);
+    }
+    dlclose(model_init_dl_handle_);
   }
 }
 

--- a/src/pt2/model_state.hh
+++ b/src/pt2/model_state.hh
@@ -80,10 +80,17 @@ class ModelState : public triton::backend::BackendModel {
   bool optimized_execution_enabled_{true};
   bool weight_sharing_enabled_{false};
 
+  // Optional per-model native init hook (MODEL_INIT_LIBRARY parameter). The
+  // backend dlopen()s this library at model load and calls its
+  // triton_pytorch_model_init() entry point; it never links against it.
+  std::string model_init_library_;
+  void* model_init_dl_handle_{nullptr};
+  void* model_init_state_{nullptr};
+
  public:
   ModelState() = delete;
 
-  virtual ~ModelState() = default;
+  virtual ~ModelState();
 
   [[nodiscard]] bool CacheCleaningEnabled() const;
 
@@ -164,5 +171,12 @@ class ModelState : public triton::backend::BackendModel {
   void AutoCompleteConfig();
 
   void ParseParameters();
+
+  // Run the optional MODEL_INIT_LIBRARY hook (no-op if unset). dlopen()s the
+  // library and calls its triton_pytorch_model_init(); throws on failure so a
+  // misconfigured hook fails model load loudly. The backend does not link it.
+  void MaybeRunModelInitHook(
+      const std::string& repository_path,
+      const std::string& repository_version, const torch::Device& device);
 };
 }  // namespace triton::backend::pytorch::pt2

--- a/src/pt2/model_state.hh
+++ b/src/pt2/model_state.hh
@@ -176,7 +176,7 @@ class ModelState : public triton::backend::BackendModel {
   // library and calls its triton_pytorch_model_init(); throws on failure so a
   // misconfigured hook fails model load loudly. The backend does not link it.
   void MaybeRunModelInitHook(
-      const std::string& repository_path,
-      const std::string& repository_version, const torch::Device& device);
+      const std::string& repository_path, const std::string& repository_version,
+      const torch::Device& device);
 };
 }  // namespace triton::backend::pytorch::pt2


### PR DESCRIPTION
## Problem

Some PT2/AOTI models need a one-time **native initialization** at model load — before the package is loaded — that cannot live inside `model.pt2`. A concrete example: a model whose custom ops resolve embedding tables from a process-global registry at execute time, where the weights are stored in sidecar files next to the package (not inside `model.pt2`). Loading the `.pt2` does not load them, so the **first inference request** fails:

```
... no binding registered for layer_id=1
-> Inductor model instance execution failure ... model_container_runner.cpp:150
```

The Triton PyTorch backend currently has no entry point to run such load-time initialization, so today it can only be done with fragile workarounds (e.g. an `LD_PRELOAD` shim that hijacks an unrelated CUDA call to piggyback on its timing).

## What this PR does

Adds a generic, optional **model-init hook** to the PT2 path. When a model's `config.pbtxt` sets the `MODEL_INIT_LIBRARY` parameter, the backend `dlopen()`s that shared library in `LoadModel()` — right before the `AOTIModelPackageLoader` is created (CUDA is already initialized there) — and calls a fixed C entry point. Design choices:

* **Backend stays generic** — it does not link against the library and knows nothing about what it does. It only `dlopen`s the `.so`, calls `triton_pytorch_model_init(model_dir, device_index)`, and releases it (`triton_pytorch_model_release` + `dlclose`) on unload. All model-specific logic lives in the user-provided plug-in, built and shipped downstream.
* **No new dependency** — the only added link is `${CMAKE_DL_LIBS}` (CMake's built-in libdl variable, for `dlopen`/`dlsym`/`dlclose`). The backend links no vendor libraries, so the stock `nvcr.io/nvidia/pytorch:26.05-py3` build is unaffected.
* **No-op by default** — a model without the parameter is completely unaffected; a `dlopen`/`dlsym` failure fails model load (fail-closed).
* **Scoped to the model lifetime** — the handle is held in `ModelState` and freed in the destructor.
* **Fixes a pre-existing parameters bug** — `ParseParameters()` was guarded by `if (!ModelConfig().Find("parameters", ...))`, so PT2 parameters were parsed only when the section was *absent*; any model that set a `parameters` block had them all (`INFERENCE_MODE`, …) silently ignored. Dropping the `!` makes them take effect.

The library must export:

```c
// Called once at model load, before the package is loaded.
void* triton_pytorch_model_init(const char* model_dir, int device_index);
// Optional; called once on unload with the handle returned above.
void  triton_pytorch_model_release(void* state);
```

Verified end-to-end on the official `nvcr.io/nvidia/tritonserver:26.05-py3` image with an AOTI model (parameter parsed → hook loaded → model READY → inference correct); also compiles against `main`.