### PR TITLE
docs: Link HSTU AOTI example from PyTorch backend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,10 +380,10 @@ export `triton_pytorch_model_init`, model load fails with an error.
 
 ### HSTU (Generative Recommenders)
 
-HSTU (Hierarchical Sequential Transduction Unit) is the encoder architecture
-behind Generative Recommenders (GRs), which reframe recommendation as a
-sequential, generative modeling problem over a user's interaction history
-rather than independently scoring candidate items.
+HSTU (Hierarchical Sequential Transduction Unit) is the sequence encoder used
+in Generative Recommenders (GRs), which reframe recommendation as a sequential,
+generative modeling problem over a user's interaction history rather than
+independently scoring candidate items.
 
 HSTU generative recommender models can be served with
 `platform: "torch_aoti"`. For an end-to-end guide, see the

--- a/README.md
+++ b/README.md
@@ -380,6 +380,11 @@ export `triton_pytorch_model_init`, model load fails with an error.
 
 ### HSTU (Generative Recommenders)
 
+HSTU (Hierarchical Sequential Transduction Unit) is the sequence-transducer
+architecture behind generative recommenders (GenRec), which reframe
+recommendation as a sequential, generative modeling problem over a user's
+interaction history instead of scoring candidates independently.
+
 HSTU generative recommender models can be served with
 `platform: "torch_aoti"`. For an end-to-end guide, see the
 [HSTU tutorial](https://github.com/triton-inference-server/tutorials/tree/main/Popular_Models_Guide/HSTU)

--- a/README.md
+++ b/README.md
@@ -378,6 +378,14 @@ export `triton_pytorch_model_init`, model load fails with an error.
 > trust boundary, but the model repository must remain a trusted,
 > operator-controlled source.
 
+### HSTU (Generative Recommenders)
+
+HSTU generative recommender models can be served with
+`platform: "torch_aoti"`. For an end-to-end guide, see the
+[HSTU tutorial](https://github.com/triton-inference-server/tutorials/tree/main/Popular_Models_Guide/HSTU)
+and the
+[recsys-examples HSTU inference docs](https://github.com/NVIDIA/recsys-examples/blob/main/examples/hstu/inference/README.md).
+
 ### PyTorch 2.0 Models
 
 PyTorch 2.0 features are available.

--- a/README.md
+++ b/README.md
@@ -380,10 +380,10 @@ export `triton_pytorch_model_init`, model load fails with an error.
 
 ### HSTU (Generative Recommenders)
 
-HSTU (Hierarchical Sequential Transduction Unit) is the sequence-transducer
-architecture behind generative recommenders (GenRec), which reframe
-recommendation as a sequential, generative modeling problem over a user's
-interaction history instead of scoring candidates independently.
+HSTU (Hierarchical Sequential Transduction Unit) is the encoder architecture
+behind Generative Recommenders (GRs), which reframe recommendation as a
+sequential, generative modeling problem over a user's interaction history
+rather than independently scoring candidate items.
 
 HSTU generative recommender models can be served with
 `platform: "torch_aoti"`. For an end-to-end guide, see the


### PR DESCRIPTION
#### What does the PR do?
Adds an **HSTU (Generative Recommenders)** subsection at the end of the AOT Inductor Support section, pointing readers at the tutorials HSTU guide and the recsys-examples HSTU inference docs for end-to-end `platform: "torch_aoti"` serving.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- tutorials: HSTU Popular Models guide (merge first so the tutorial link resolves)
- server: https://github.com/triton-inference-server/server/pull/8895 (Getting Started toc)

#### Where should the reviewer start?
- `README.md` — `### HSTU (Generative Recommenders)` under AOT Inductor Support

#### Test plan:
- Confirm the new subsection sits after `MODEL_INIT_LIBRARY` and before PyTorch 2.0 / TorchScript
- After the tutorials HSTU guide lands, verify both linked URLs resolve

- CI Pipeline ID:
N/A (docs-only)

#### Caveats:
- The tutorials HSTU page should merge before or with this PR so the tutorial URL is live.

#### Background
HSTU generative recommenders are served on Triton via Torch AOTI. This cross-link surfaces that path from the backend README without duplicating recsys-examples runbooks.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to accompanying tutorials and server documentation PRs for HSTU / Torch AOTI