### PR TITLE
Fix swapped ReportStatistics timestamp args in PT2/AOTI backend

### DIFF
--- a/src/pt2/model_instance_state.cc
+++ b/src/pt2/model_instance_state.cc
@@ -1037,9 +1037,9 @@ ModelInstanceState::ProcessRequests(
             /* request= */ request,
             /* success= */ (responses[r] != nullptr),
             /* exec_start_ns= */ exec_start_ns,
-            /* exec_end_ns= */ exec_end_ns,
             /* compute_start_ns= */ compute_start_ns,
-            /* compute_end_ns= */ compute_end_ns)) {
+            /* compute_end_ns= */ compute_end_ns,
+            /* exec_end_ns= */ exec_end_ns)) {
       TRITON_LOG_ERROR(
           "Failed to report statistics for request "
           << r << " of model instance \"" << Name()


### PR DESCRIPTION
## Summary

`TRITONBACKEND_ModelInstanceReportStatistics` expects timestamps in the order
`(exec_start_ns, compute_start_ns, compute_end_ns, exec_end_ns)`, but
`ModelInstanceState::ProcessRequests` in the PT2/AOTI instance state passed
`exec_end_ns` before `compute_start_ns`/`compute_end_ns`. Triton core then
interprets `exec_end_ns` as `compute_input_end_ns`, and the resulting
subtraction underflows as an unsigned 64-bit value, so
`nv_inference_compute_infer_summary_us` reports an enormous bogus number
(~18446744074s) instead of the real compute latency.

This reorders the arguments to match the documented header signature and the
legacy (non-PT2) PyTorch backend's call convention, which already does this
correctly. The batch-level `TRITONBACKEND_ModelInstanceReportBatchStatistics`
call a few lines below was already in the correct order, so no other changes
are needed.

Ref: triton-inference-server/server#8874

## Test plan

- [x] `pre-commit run` (clang-format, codespell, etc.) passes on the changed file
- [x] Verified new argument order against `TRITONBACKEND_ModelInstanceReportStatistics`'s
      declaration in `triton-inference-server/core`'s `tritonbackend.h`